### PR TITLE
Changing copy based on yarn.lock

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 name: Create Release
 
 jobs:
-  test:
+  release:
     name: Release a new version
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,18 +2,24 @@ on:
   push:
     # Sequence of patterns matched against refs/tags
     tags:
-      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 name: Create Release
 
 jobs:
-  build:
-    name: Create Release
+  test:
+    name: Release a new version
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - uses: actions/checkout@master
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: Install dependencies
+        run: |
+          npm install
       - name: Create Release
         run: npm run release
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }} # this token is generated via npm token create
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ You can configure `codeowners-generator` from several places:
 
 ### CLI options
 
-- **includes** (`--includes`): The glob used to find CODEOWNERS files in the repo `default: **/CODEOWNERS`a
+- **includes** (`--includes`): The glob used to find CODEOWNERS files in the repo `default: ['**/CODEOWNERS', '!CODEOWNERS', '!node_modules']`
 
-- **useMaintainers** (`--useMaintainers`): It will use `maintainers` field from package.json to generate codeowners `default: **/package.json`
+- **useMaintainers** (`--useMaintainers`): It will use `maintainers` field from package.json to generate codeowners, by default it will use `**/package.json`
 
 for more details you can invoke:
 

--- a/__tests__/generate.spec.ts
+++ b/__tests__/generate.spec.ts
@@ -66,7 +66,7 @@ describe('Generate', () => {
 
       #################################### Generated content - do not edit! ####################################
       # This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator/README.md)
-      # To re-generate, run npm run codeowners-generator generate. Don't worry, the content outside this block will be kept.
+      # To re-generate, run \`yarn codeowners-generator generate\`. Don't worry, the content outside this block will be kept.
 
       # Rule extracted from dir1/CODEOWNERS
       dir1/*.ts @eeny @meeny
@@ -100,7 +100,7 @@ describe('Generate', () => {
           "CODEOWNERS",
           "#################################### Generated content - do not edit! ####################################
       # This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator/README.md)
-      # To re-generate, run npm run codeowners-generator generate. Don't worry, the content outside this block will be kept.
+      # To re-generate, run \`npm run codeowners-generator generate\`. Don't worry, the content outside this block will be kept.
 
       # Rule extracted from dir1/CODEOWNERS
       dir1/*.ts @eeny @meeny
@@ -159,7 +159,7 @@ describe('Generate', () => {
     expect(writeFile.mock.calls[0][1]).toMatchInlineSnapshot(`
       "#################################### Generated content - do not edit! ####################################
       # This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator/README.md)
-      # To re-generate, run npm run codeowners-generator generate. Don't worry, the content outside this block will be kept.
+      # To re-generate, run \`npm run codeowners-generator generate\`. Don't worry, the content outside this block will be kept.
 
       # Rule extracted from dir5/package.json
       dir5/ friend@example.com other@example.com
@@ -211,7 +211,7 @@ describe('Generate', () => {
     expect(writeFile.mock.calls[0][1]).toMatchInlineSnapshot(`
       "#################################### Generated content - do not edit! ####################################
       # This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator/README.md)
-      # To re-generate, run npm run codeowners-generator generate. Don't worry, the content outside this block will be kept.
+      # To re-generate, run \`npm run codeowners-generator generate\`. Don't worry, the content outside this block will be kept.
 
       # Rule extracted from dir5/package.json
       dir5/ friend@example.com other@example.com

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -13,8 +13,14 @@ const debug = logger('generate');
 type Generate = (options: GenerateInput) => Promise<ownerRule[]>;
 type GenerateInput = { rootDir: string; verifyPaths?: boolean; useMaintainers?: boolean; includes?: string[] };
 
-export const generate: Generate = async ({ rootDir, includes = INCLUDES, useMaintainers = false }) => {
-  const globs = useMaintainers ? [...includes, ...PACKAGE_JSON_PATTERN] : includes;
+export const generate: Generate = async ({ rootDir, includes, useMaintainers = false }) => {
+  debug('input:', rootDir, includes, useMaintainers);
+
+  const includePatterns = includes && includes.length ? includes : INCLUDES;
+
+  debug('includePatterns:', includePatterns);
+
+  const globs = useMaintainers ? [...includePatterns, ...PACKAGE_JSON_PATTERN] : includePatterns;
 
   debug('provided globs:', globs);
 
@@ -68,6 +74,7 @@ export const command = async (command: CommandGenerate): Promise<void> => {
   const { output, verifyPaths, useMaintainers } = command;
 
   const loader = ora('generating codeowners...').start();
+
   debug('Options:', { ...globalOptions, useMaintainers, output });
 
   try {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,4 +1,5 @@
 import { stripIndents } from 'common-tags';
+import { existsSync } from 'fs';
 export const SUCCESS_SYMBOL = '💫';
 export const SHRUG_SYMBOL = '¯\\_(ツ)_/¯';
 export const OUTPUT = 'CODEOWNERS';
@@ -6,18 +7,26 @@ export const INCLUDES = ['**/CODEOWNERS', '!CODEOWNERS', '!node_modules'];
 export const PACKAGE_JSON_PATTERN = ['**/package.json'];
 export const MAINTAINERS_EMAIL_PATTERN = /<(.+)>/;
 export const IGNORE_FILES_PATTERN = ['.gitignore'];
+
 export const CONTENT_MARK = stripIndents`
 #################################### Generated content - do not edit! ####################################
 `;
-export const CONTENT_LEGEND = stripIndents`
+const CONTENT_LEGEND_NPM = stripIndents`
 # This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator/README.md)
-# To re-generate, run npm run codeowners-generator generate. Don't worry, the content outside this block will be kept. 
+# To re-generate, run \`npm run codeowners-generator generate\`. Don't worry, the content outside this block will be kept. 
 `;
+const CONTENT_LEGEND_YARN = stripIndents`
+# This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator/README.md)
+# To re-generate, run \`yarn codeowners-generator generate\`. Don't worry, the content outside this block will be kept. 
+`;
+
+const getContentLegend = () => (existsSync('./yarn.lock') ? CONTENT_LEGEND_YARN : CONTENT_LEGEND_NPM);
+
 export const contentTemplate = (generatedContent: string, originalContent: string): string => {
   return stripIndents`
   ${originalContent && originalContent}
   ${CONTENT_MARK}
-  ${CONTENT_LEGEND}\n
+  ${getContentLegend()}\n
   ${generatedContent}\n
   ${CONTENT_MARK}\n
 `;

--- a/src/utils/getGlobalOptions.ts
+++ b/src/utils/getGlobalOptions.ts
@@ -1,15 +1,14 @@
 import { getCustomConfiguration } from './getCustomConfiguration';
-
 interface GlobalOptions {
-  includes?: string[];
+  includes: string[];
 }
 export interface Command {
-  parent: GlobalOptions;
+  parent: Partial<GlobalOptions>;
 }
 
 const makeArray = (field: unknown) => (field && Array.isArray(field) ? field : [field].filter(Boolean));
 
-const getOptionsFromCommand = (command: Command): Partial<GlobalOptions> => {
+const getOptionsFromCommand = (command: Command): GlobalOptions => {
   const {
     parent: { includes },
   } = command;


### PR DESCRIPTION
When adding the copy on the generated content, we check if yarn.lock is present so we can recommend the right command to run. 

I've also excluded `node_modules` as a default to avoid going through all the node_modules files.  