### PR TITLE
Lowering engine requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "release": "npm run build && npm publish"
   },
   "engines": {
-    "node": ">12.0.0"
+    "node": ">10.0.0"
   },
   "keywords": [
     "cli",


### PR DESCRIPTION
We are requiring node 12 when the code (bin) is used is transpiled with [ncc](https://github.com/vercel/ncc). 