### PR TITLE
removing default from cli in favor of generate default instead. 

### DIFF
--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -19,7 +19,7 @@ program
     'For every package.json found, generate a CODEOWNERS entry using the maintainers field',
     false
   )
-  .option('--output [output file]', 'The output path and name of the file', 'CODEOWNERS')
+  .option('--output [output file]', 'The output path and name of the file, (default: CODEOWNERS)')
   .action(generateCommand);
 
 program.parse(process.argv);


### PR DESCRIPTION
the CLI provided a default value already and this overrides the custom configuration if provided. 

relying on the default value provided in the `generate` instead. 