### PR TITLE
Update Readme to include the mention about matching package.json syntax for authors/contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@
 
 [CODEOWNERS](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) are automatically requested for review when someone opens a pull request that modifies code that they own. This is a great feature, but when working on monorepos ownership is shared between teams and it becomes difficult to maintain.
 
-`codeowners-generator` allows you to position CODEOWNERS files anywhere in your project tree and it will take care of compiling all the files into a single generated file, that Github can understand. It also can read the maintainers fields (`contributors`, `author` and alternatively `maintainers`) in `package.json` (`useMaintainers` option in the cli ) making easy to keep CODEOWNERS and package.json in sync.
+`codeowners-generator` allows you to position CODEOWNERS files anywhere in your project tree and it will take care of compiling all the files into a single generated file, that Github can understand. It also can read the maintainers fields (`contributors`, `author` and alternatively `maintainers`) in `package.json` (`useMaintainers` option in the cli ) making easy to keep CODEOWNERS and package.json in sync. Make sure the `author`/`contributors` syntax matches with `package.json` expected syntax from the [documentation](https://docs.npmjs.com/files/package.json#people-fields-author-contributors).
 
 ### Built With
 


### PR DESCRIPTION
I was initially having issues with generating codeowners for our project, when I realized my syntax for contributors in package.json was incorrect. Updating the readme here so that other don't make that mistake. 