### PR TITLE
building the source code to be used programatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: npm run build
+      - run: npm run build-cli
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -42,7 +42,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   build:
-    name: Run build
+    name: Run build-cli
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -51,7 +51,6 @@ jobs:
         with:
           node-version: 12.x
       - name: Install dependencies
-        run: |
-          npm install
+        run: npm install
       - name: Build
-        run: npm run build
+        run: npm run build-cli

--- a/.github/workflows/validation_on_master.yml
+++ b/.github/workflows/validation_on_master.yml
@@ -54,7 +54,6 @@ jobs:
         with:
           node-version: 12.x
       - name: Install dependencies
-        run: |
-          npm install
+        run: npm install
       - name: Build
-        run: npm run build
+        run: npm run build-cli

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@ node_modules
 .vscode/
 # ignore codecoverage output
 coverage/
+# ignore build/ output
+build/
 # ignore dist/ output
 dist/

--- a/package.json
+++ b/package.json
@@ -4,17 +4,18 @@
   "license": "MIT",
   "version": "1.2.5",
   "description": " CODEOWNERS generator with mono repos",
-  "main": "index.ts",
+  "main": "build/index.js",
   "bin": {
     "codeowners-generator": "dist/index.js"
   },
   "scripts": {
     "precommit": "lint-staged",
     "test": "jest",
-    "build": "ncc build ./src/bin/cli.ts",
+    "build-cli": "ncc build ./src/bin/cli.ts",
+    "build": "ncc build ./index.ts -o build",
     "lint": "eslint src/* --ext .ts",
     "version": "auto-changelog -p && git add CHANGELOG.md",
-    "release": "npm run build && npm publish"
+    "release": "npm run build && npm run build-cli && npm publish"
   },
   "engines": {
     "node": ">10.0.0"


### PR DESCRIPTION
Before the only transpiled code we were generating was the one used for the cli. 

We are in need of using `codeowners-generator` programmatically so we decided to add a new dist in the package (build/) to transpile the source code as well. 