### PR TITLE
adding groupSourceComments

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ You can configure `codeowners-generator` from several places:
 
 - **groupSourceComments** (`--group-source-comments`): It will add a comment per source file, instead of adding one on every rule found. Useful if your codeowners file gets too noisy.
 
-  For more details you can invoke:
+For more details you can invoke:
 
 ```sh
   codeowners-generator --help

--- a/README.md
+++ b/README.md
@@ -118,7 +118,9 @@ You can configure `codeowners-generator` from several places:
 
 - **useMaintainers** (`--use-maintainers`): It will use `maintainers` field from package.json to generate codeowners, by default it will use `**/package.json`
 
-for more details you can invoke:
+- **groupSourceComments** (`--group-source-comments`): It will add a comment per source file, instead of adding one on every rule found. Useful if your codeowners file gets too noisy.
+
+  For more details you can invoke:
 
 ```sh
   codeowners-generator --help
@@ -134,7 +136,8 @@ You can also define custom configuration in your package:
   "codeowners-generator": {
     "includes": ["**/CODEOWNERS"],
     "output": ".github/CODEOWNERS",
-    "useMaintainers": true
+    "useMaintainers": true,
+    "groupSourceComments": true
   },
   "scripts": {
     "codeowners": " codeowners-generator generate"

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ You can configure `codeowners-generator` from several places:
 
 - **useMaintainers** (`--use-maintainers`): It will use `maintainers` field from package.json to generate codeowners, by default it will use `**/package.json`
 
-- **groupSourceComments** (`--group-source-comments`): It will add a comment per source file, instead of adding one on every rule found. Useful if your codeowners file gets too noisy.
+- **groupSourceComments** (`--group-source-comments`): Instead of generating one comment per rule, enabling this flag will group them, reducing comments to one per source file. Useful if your codeowners file gets too noisy.
 
 For more details you can invoke:
 

--- a/__tests__/generate.spec.ts
+++ b/__tests__/generate.spec.ts
@@ -102,10 +102,10 @@ describe('Generate', () => {
       # This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator/README.md)
       # To re-generate, run \`npm run codeowners-generator generate\`. Don't worry, the content outside this block will be kept.
 
-      # Rule extracted from dir1/CODEOWNERS
+      # Rules extracted from dir1/CODEOWNERS
       dir1/*.ts @eeny @meeny
       dir1/README.md @miny
-      # Rule extracted from dir2/CODEOWNERS
+      # Rules extracted from dir2/CODEOWNERS
       dir2/*.ts @moe
       dir2/dir3/*.ts @miny
       # Rule extracted from dir2/dir3/CODEOWNERS
@@ -251,10 +251,10 @@ describe('Generate', () => {
       dir5/ friend@example.com other@example.com
       # Rule extracted from dir2/dir1/package.json
       dir2/dir1/ friend@example.com other@example.com
-      # Rule extracted from dir1/CODEOWNERS
+      # Rules extracted from dir1/CODEOWNERS
       dir1/*.ts @eeny @meeny
       dir1/README.md @miny
-      # Rule extracted from dir2/CODEOWNERS
+      # Rules extracted from dir2/CODEOWNERS
       dir2/*.ts @moe
       dir2/dir3/*.ts @miny
       # Rule extracted from dir2/dir3/CODEOWNERS

--- a/__tests__/generate.spec.ts
+++ b/__tests__/generate.spec.ts
@@ -83,6 +83,39 @@ describe('Generate', () => {
       ]
     `);
   });
+  it('should generate a CODEOWNERS FILE with groupSourceComments', async () => {
+    sync.mockReturnValueOnce(Object.keys(files));
+
+    sync.mockReturnValueOnce(['.gitignore']);
+
+    readFile.mockImplementation((file: keyof typeof withGitIgnore, callback: Callback) => {
+      const content = readFileSync(path.join(__dirname, withGitIgnore[file]));
+      callback(null, content);
+    });
+
+    await generateCommand({ parent: {}, output: 'CODEOWNERS', groupSourceComments: true });
+    expect(writeFile.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "CODEOWNERS",
+          "#################################### Generated content - do not edit! ####################################
+      # This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator/README.md)
+      # To re-generate, run \`npm run codeowners-generator generate\`. Don't worry, the content outside this block will be kept.
+
+      # Rule extracted from dir1/CODEOWNERS
+      dir1/*.ts @eeny @meeny
+      dir1/README.md @miny
+      # Rule extracted from dir2/CODEOWNERS
+      dir2/*.ts @moe
+      dir2/dir3/*.ts @miny
+      # Rule extracted from dir2/dir3/CODEOWNERS
+      dir2/dir3/*.ts @miny
+
+      #################################### Generated content - do not edit! ####################################",
+        ],
+      ]
+    `);
+  });
   it('should generate a CODEOWNERS FILE', async () => {
     sync.mockReturnValueOnce(Object.keys(files));
 
@@ -176,7 +209,7 @@ describe('Generate', () => {
       #################################### Generated content - do not edit! ####################################"
     `);
   });
-  it('should generate a CODEOWNERS FILE with package.maintainers field using cosmiconfig', async () => {
+  it('should generate a CODEOWNERS FILE with package.maintainers field and groupSourceComments using cosmiconfig', async () => {
     search.mockImplementationOnce(() =>
       Promise.resolve({
         isEmpty: false,
@@ -184,6 +217,7 @@ describe('Generate', () => {
         config: {
           output: '.github/CODEOWNERS',
           useMaintainers: true,
+          groupSourceComments: true,
           includes: ['dir1/*', 'dir2/*', 'dir5/*', 'dir6/*', 'dir7/*'],
         },
       })
@@ -219,11 +253,9 @@ describe('Generate', () => {
       dir2/dir1/ friend@example.com other@example.com
       # Rule extracted from dir1/CODEOWNERS
       dir1/*.ts @eeny @meeny
-      # Rule extracted from dir1/CODEOWNERS
       dir1/README.md @miny
       # Rule extracted from dir2/CODEOWNERS
       dir2/*.ts @moe
-      # Rule extracted from dir2/CODEOWNERS
       dir2/dir3/*.ts @miny
       # Rule extracted from dir2/dir3/CODEOWNERS
       dir2/dir3/*.ts @miny

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -19,7 +19,11 @@ program
     'For every package.json found, generate a CODEOWNERS entry using the maintainers field',
     false
   )
-  .option('--group-source-comments', 'Group rules by source, reducing the amount of comments added', false)
+  .option(
+    '--group-source-comments',
+    'Instead of generating one comment per rule, enabling this flag will group them, reducing comments to one per source file. Useful if your codeowners file gets too noisy',
+    false
+  )
   .option('--output [output file]', 'The output path and name of the file, (default: CODEOWNERS)')
   .action(generateCommand);
 

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -19,6 +19,7 @@ program
     'For every package.json found, generate a CODEOWNERS entry using the maintainers field',
     false
   )
+  .option('--group-source-comments', 'Group rules by source, reducing the amount of comments added', false)
   .option('--output [output file]', 'The output path and name of the file, (default: CODEOWNERS)')
   .action(generateCommand);
 

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -66,6 +66,7 @@ interface CommandGenerate extends Command {
   output?: string;
   verifyPaths?: boolean;
   useMaintainers?: boolean;
+  groupSourceComments?: boolean;
   includes?: string[];
 }
 
@@ -78,13 +79,15 @@ export const command = async (command: CommandGenerate): Promise<void> => {
 
   const loader = ora('generating codeowners...').start();
 
-  debug('Options:', { ...globalOptions, useMaintainers, output });
+  const groupSourceComments = globalOptions.groupSourceComments || command.groupSourceComments;
+
+  debug('Options:', { ...globalOptions, useMaintainers, groupSourceComments, output });
 
   try {
     const ownerRules = await generate({ rootDir: __dirname, verifyPaths, useMaintainers, ...globalOptions });
 
     if (ownerRules.length) {
-      await createOwnersFile(output, ownerRules);
+      await createOwnersFile(output, ownerRules, groupSourceComments);
 
       loader.stopAndPersist({ text: `CODEOWNERS file was created! location: ${output}`, symbol: SUCCESS_SYMBOL });
     } else {

--- a/src/utils/codeowners.ts
+++ b/src/utils/codeowners.ts
@@ -1,10 +1,10 @@
 import fs from 'fs';
-import { stripIndents } from 'common-tags';
 import parseGlob from 'parse-glob';
-import { MAINTAINERS_EMAIL_PATTERN, contentTemplate, CONTENT_MARK, CHARACTER_RANGE_PATTERN } from './constants';
+import { MAINTAINERS_EMAIL_PATTERN, contentTemplate, CONTENT_MARK, CHARACTER_RANGE_PATTERN, rulesBlockTemplate } from './constants';
 import { dirname, join } from 'path';
 import { readContent } from './readContent';
 import { logger } from '../utils/debug';
+import groupBy from 'lodash.groupby';
 
 const debug = logger('utils/codeowners');
 
@@ -35,7 +35,11 @@ const filterGeneratedContent = (content: string) => {
     }, [] as string[])
     .join('\n');
 };
-export const createOwnersFile = async (outputFile: string, ownerRules: ownerRule[]): Promise<void> => {
+export const createOwnersFile = async (
+  outputFile: string,
+  ownerRules: ownerRule[],
+  groupSourceComments = false
+): Promise<void> => {
   let originalContent = '';
 
   if (fs.existsSync(outputFile)) {
@@ -44,12 +48,18 @@ export const createOwnersFile = async (outputFile: string, ownerRules: ownerRule
     originalContent = filterGeneratedContent(originalContent);
   }
 
-  const content = ownerRules.map(
-    (rule) => stripIndents` 
-    # Rule extracted from ${rule.filePath}
-    ${rule.glob} ${rule.owners.join(' ')}
-    `
-  );
+  let content = [] as string[];
+
+  if (groupSourceComments) {
+    const groupedRules = groupBy(ownerRules, (rule) => rule.filePath);
+
+    content = Object.keys(groupedRules).reduce((memo, filePath) => {
+      const rules = groupedRules[filePath].map((rule) => `${rule.glob} ${rule.owners.join(' ')}`);
+      return [...memo, rulesBlockTemplate(filePath, rules)];
+    }, [] as string[]);
+  } else {
+    content = ownerRules.map((rule) => rulesBlockTemplate(rule.filePath, [`${rule.glob} ${rule.owners.join(' ')}`]));
+  }
 
   fs.writeFileSync(outputFile, contentTemplate(content.join('\n'), originalContent));
 };
@@ -113,7 +123,7 @@ export const loadCodeOwnerFiles = async (dirname: string, files: string[]): Prom
     files.map(async (filePath) => {
       const content = await readContent(filePath);
 
-      return parseCodeOwner(filePath.replace(`${dirname}/`, ''), content);
+      return parseCodeOwner(filePath.replace(`${dirname} / `, ''), content);
     })
   );
   return codeOwners.reduce((memo, rules) => [...memo, ...rules], []);
@@ -152,7 +162,7 @@ const getOwnersFromMaintainerField = (filePath: string, content: string): ownerR
 
       if (!owners.length) {
         throw new Error(
-          `malformed maintainer entry ${maintainers} this file will be skipped. for more info https://classic.yarnpkg.com/en/docs/package-json/#toc-maintainers`
+          `malformed maintainer entry ${maintainers} this file will be skipped.for more info https://classic.yarnpkg.com/en/docs/package-json/#toc-maintainers`
         );
       }
 

--- a/src/utils/codeowners.ts
+++ b/src/utils/codeowners.ts
@@ -123,7 +123,7 @@ export const loadCodeOwnerFiles = async (dirname: string, files: string[]): Prom
     files.map(async (filePath) => {
       const content = await readContent(filePath);
 
-      return parseCodeOwner(filePath.replace(`${dirname} / `, ''), content);
+      return parseCodeOwner(filePath.replace(`${dirname}/`, ''), content);
     })
   );
   return codeOwners.reduce((memo, rules) => [...memo, ...rules], []);
@@ -162,7 +162,7 @@ const getOwnersFromMaintainerField = (filePath: string, content: string): ownerR
 
       if (!owners.length) {
         throw new Error(
-          `malformed maintainer entry ${maintainers} this file will be skipped.for more info https://classic.yarnpkg.com/en/docs/package-json/#toc-maintainers`
+          `malformed maintainer entry ${maintainers} this file will be skipped. For more info https://classic.yarnpkg.com/en/docs/package-json/#toc-maintainers`
         );
       }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -35,7 +35,7 @@ export const contentTemplate = (generatedContent: string, originalContent: strin
 
 export const rulesBlockTemplate = (source: string, entries: string[]): string => {
   return stripIndents`
-  # Rule${entries.length > 1 && 's'} extracted from ${source}
+  # Rule${entries.length > 1 ? 's' : ''} extracted from ${source}
   ${entries.join('\n')}
   `;
 };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -35,7 +35,7 @@ export const contentTemplate = (generatedContent: string, originalContent: strin
 
 export const rulesBlockTemplate = (source: string, entries: string[]): string => {
   return stripIndents`
-  # Rule${entries.length && 's'} extracted from ${source}
+  # Rule${entries.length > 1 && 's'} extracted from ${source}
   ${entries.join('\n')}
   `;
 };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -33,9 +33,9 @@ export const contentTemplate = (generatedContent: string, originalContent: strin
 `;
 };
 
-export const rulesBlockTemplate = (source: string, entry: string[]): string => {
+export const rulesBlockTemplate = (source: string, entries: string[]): string => {
   return stripIndents`
-  # Rule extracted from ${source}
-  ${entry.join('\n')}
+  # Rule${entries.length && 's'} extracted from ${source}
+  ${entries.join('\n')}
   `;
 };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -32,3 +32,10 @@ export const contentTemplate = (generatedContent: string, originalContent: strin
   ${CONTENT_MARK}\n
 `;
 };
+
+export const rulesBlockTemplate = (source: string, entry: string[]): string => {
+  return stripIndents`
+  # Rule extracted from ${source}
+  ${entry.join('\n')}
+  `;
+};

--- a/src/utils/getCustomConfiguration.ts
+++ b/src/utils/getCustomConfiguration.ts
@@ -6,7 +6,12 @@ import packageJSON from '../../package.json';
 import { logger } from './debug';
 
 const debug = logger('customConfiguration');
-export type CustomConfig = { includes?: string[]; useMaintainers?: boolean; output?: string };
+export type CustomConfig = {
+  includes?: string[];
+  useMaintainers?: boolean;
+  groupSourceComments?: boolean;
+  output?: string;
+};
 
 export const getCustomConfiguration = async (): Promise<CustomConfig | void> => {
   const loader = ora('Loading available configuration').start();

--- a/src/utils/getGlobalOptions.ts
+++ b/src/utils/getGlobalOptions.ts
@@ -2,6 +2,8 @@ import { getCustomConfiguration } from './getCustomConfiguration';
 interface GlobalOptions {
   includes?: string[];
   output?: string;
+
+  groupSourceComments?: boolean;
 }
 export interface Command {
   parent: Partial<GlobalOptions>;


### PR DESCRIPTION
## Description

This PR addresses the requested feature in (closes #164) by @gustavkj 

the option is `groupSourceComments` or `--group-source-comments` when used in the cli. 

It will avoid adding a comment per rule found and instead will group the comment per source. 

