### PR TITLE
add `isValidCodeownersGlob` function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1397,12 +1397,6 @@
         "@types/node": "*"
       }
     },
-    "@types/is-valid-glob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
-      "integrity": "sha512-S/3Q7u9Je/8rEN+5OVM5EJmp6a9UBBvyXZtZ7YSmNkkOaPeTjTs/5LLbl3bPgtJyA2tcDV3ADQvkzh0adGd9dA==",
-      "dev": true
-    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
@@ -1474,6 +1468,12 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
+    "@types/parse-glob": {
+      "version": "3.0.29",
+      "resolved": "https://registry.npmjs.org/@types/parse-glob/-/parse-glob-3.0.29.tgz",
+      "integrity": "sha1-akDsfr0kGO5p7jl+SOQhaSaKEL8=",
       "dev": true
     },
     "@types/parse-json": {
@@ -3820,6 +3820,38 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "requires": {
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "requires": {
+            "is-glob": "^2.0.0"
+          }
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
+      }
+    },
     "glob-parent": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
@@ -4316,6 +4348,11 @@
       "dev": true,
       "optional": true
     },
+    "is-dotfile": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -4395,11 +4432,6 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
-    },
-    "is-valid-glob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
-      "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao="
     },
     "is-windows": {
       "version": "1.0.2",
@@ -7966,6 +7998,32 @@
       "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
       "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw==",
       "dev": true
+    },
+    "parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "requires": {
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
+      }
     },
     "parse-json": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -107,17 +107,17 @@
     "debug": "4.3.1",
     "fast-glob": "3.2.5",
     "ignore": "^5.1.8",
-    "is-valid-glob": "1.0.0",
     "lodash.groupby": "4.6.0",
-    "ora": "5.3.0"
+    "ora": "5.3.0",
+    "parse-glob": "^3.0.4"
   },
   "devDependencies": {
     "@types/common-tags": "1.8.0",
     "@types/debug": "4.1.5",
-    "@types/is-valid-glob": "1.0.0",
     "@types/jest": "26.0.20",
     "@types/lodash.groupby": "4.6.6",
     "@types/node": "13.13.40",
+    "@types/parse-glob": "^3.0.29",
     "@typescript-eslint/eslint-plugin": "4.14.0",
     "@typescript-eslint/parser": "4.14.0",
     "@zeit/ncc": "0.22.3",

--- a/src/utils/codeowners.spec.ts
+++ b/src/utils/codeowners.spec.ts
@@ -1,0 +1,42 @@
+import { loadCodeOwnerFiles } from './codeowners';
+import { readContent } from './readContent';
+import { mocked } from 'ts-jest/utils';
+
+jest.mock('./readContent');
+
+const readContentMock = mocked(readContent);
+
+describe('Codeowners', () => {
+  describe('loadCodeOwnerFiles', () => {
+    const invalidRuleCases = [
+      ['should throw if a rule is missing owners', '*.ts', '*.ts in dir1/CODEOWNERS can not be parsed'],
+      ['should throw if a rule is missing a file pattern', ' @eeny', ' @eeny in dir1/CODEOWNERS can not be parsed'],
+      [
+        'should throw if a rule is using ! to negate a pattern',
+        '!*.ts @eeny',
+        '!*.ts @eeny in dir1/CODEOWNERS can not be parsed',
+      ],
+      [
+        'should throw if a pattern is using [ ] to define a character range',
+        '[a-z].ts @meeny',
+        '[a-z].ts @meeny in dir1/CODEOWNERS can not be parsed',
+      ],
+      [
+        'should throw if a pattern is using braces for brace expansion or brace sets',
+        '*.{txt,md} @miny',
+        '*.{txt,md} @miny in dir1/CODEOWNERS can not be parsed',
+      ],
+      [
+        'should throw if a pattern is escaping a pattern starting with # using \\ so it is treated as a pattern and not a comment',
+        '\\#fileName @moe',
+        '\\#fileName @moe in dir1/CODEOWNERS can not be parsed',
+      ],
+    ];
+
+    it.each(invalidRuleCases)('%s (%s)', async (_name, rule, expectedError) => {
+      readContentMock.mockResolvedValueOnce(rule);
+
+      await expect(loadCodeOwnerFiles('/root', ['/root/dir1/CODEOWNERS'])).rejects.toThrowError(expectedError);
+    });
+  });
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -7,6 +7,7 @@ export const INCLUDES = ['**/CODEOWNERS', '!CODEOWNERS', '!.github/CODEOWNERS', 
 export const PACKAGE_JSON_PATTERN = ['**/package.json'];
 export const MAINTAINERS_EMAIL_PATTERN = /<(.+)>/;
 export const IGNORE_FILES_PATTERN = ['.gitignore'];
+export const CHARACTER_RANGE_PATTERN = /\[(?:.-.)+\]/;
 
 export const CONTENT_MARK = stripIndents`
 #################################### Generated content - do not edit! ####################################


### PR DESCRIPTION
Adds a function to validate codeowners glob patterns according to the [CODEOWNERS syntax](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax) and [gitignore syntax](https://git-scm.com/docs/gitignore#_pattern_format) it extends. 

It also removed `is-valid-glob` since it apparently pretty much checks if it's [a non-empty string](https://github.com/micromatch/is-valid-glob/blob/c18c82999df11133c5946f9a21ef74a0ebf88334/index.js#L4-L6): 

```js
  if (typeof glob === 'string' && glob.length > 0) {
    return true;
  }
```

See https://github.com/gagoar/codeowners-generator/pull/161#issuecomment-763196641 and https://github.com/gagoar/codeowners-generator/issues/160#issuecomment-764433649 for additional context for the PR.