### PR TITLE
fix compatibility with commander v7

### DIFF
--- a/__tests__/generate.spec.ts
+++ b/__tests__/generate.spec.ts
@@ -54,7 +54,7 @@ describe('Generate', () => {
       callback(null, content);
     });
 
-    await generateCommand({ parent: {}, output: 'CODEOWNERS' });
+    await generateCommand({ output: 'CODEOWNERS' }, { parent: {} });
     expect(writeFile.mock.calls[0]).toMatchInlineSnapshot(`
       Array [
         "CODEOWNERS",
@@ -93,7 +93,7 @@ describe('Generate', () => {
       callback(null, content);
     });
 
-    await generateCommand({ parent: {}, output: 'CODEOWNERS' });
+    await generateCommand({ output: 'CODEOWNERS' }, { parent: {} });
     expect(writeFile.mock.calls).toMatchInlineSnapshot(`
       Array [
         Array [
@@ -149,7 +149,7 @@ describe('Generate', () => {
       callback(null, content);
     });
 
-    await generateCommand({ parent: {} });
+    await generateCommand({}, { parent: {} });
     expect(search).toHaveBeenCalled();
     expect(writeFile.mock.calls[0][1]).toMatchInlineSnapshot(`
       "#################################### Generated content - do not edit! ####################################
@@ -206,7 +206,7 @@ describe('Generate', () => {
       callback(null, content);
     });
 
-    await generateCommand({ parent: {} });
+    await generateCommand({}, { parent: {} });
     expect(search).toHaveBeenCalled();
     expect(writeFile.mock.calls[0][1]).toMatchInlineSnapshot(`
       "#################################### Generated content - do not edit! ####################################
@@ -255,7 +255,7 @@ describe('Generate', () => {
       callback(null, content);
     });
 
-    await generateCommand({ parent: {}, output: 'CODEOWNERS', useMaintainers: true });
+    await generateCommand({ output: 'CODEOWNERS', useMaintainers: true }, { parent: {} });
     expect(writeFile.mock.calls[0][1]).toMatchInlineSnapshot(`
       "#################################### Generated content - do not edit! ####################################
       # This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator/README.md)
@@ -341,11 +341,14 @@ describe('Generate', () => {
 
   it('should not find any rules', async () => {
     sync.mockReturnValue([]);
-    await generateCommand({
-      parent: {
-        includes: ['**/NOT_STANDARD_CODEOWNERS'],
-      },
-    });
+    await generateCommand(
+      {},
+      {
+        parent: {
+          includes: ['**/NOT_STANDARD_CODEOWNERS'],
+        },
+      }
+    );
     expect(stopAndPersist.mock.calls).toMatchInlineSnapshot(`
       Array [
         Array [
@@ -378,7 +381,7 @@ describe('Generate', () => {
     });
     search.mockImplementationOnce(() => Promise.reject(new Error('some malformed configuration')));
 
-    await generateCommand({ parent: {} });
+    await generateCommand({}, { parent: {} });
     expect(fail.mock.calls).toMatchInlineSnapshot(`
       Array [
         Array [
@@ -397,7 +400,7 @@ describe('Generate', () => {
       callback(null, content);
     });
 
-    await generateCommand({ parent: {} });
+    await generateCommand({}, { parent: {} });
     expect(writeFile).toHaveBeenCalled();
   });
 
@@ -424,7 +427,7 @@ describe('Generate', () => {
       callback(null, content);
     });
 
-    await generateCommand({ parent: {}, output: 'CODEOWNERS' });
+    await generateCommand({ output: 'CODEOWNERS' }, { parent: {} });
     expect(fail.mock.calls[0]).toMatchInlineSnapshot(`
       Array [
         "We encountered an error: Error: *.ts in dir4/CODEOWNERS can not be parsed",

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -62,19 +62,19 @@ export const generate: Generate = async ({ rootDir, includes, useMaintainers = f
   }
 };
 
-interface CommandGenerate extends Command {
+interface Options {
   output?: string;
   verifyPaths?: boolean;
   useMaintainers?: boolean;
   includes?: string[];
 }
 
-export const command = async (command: CommandGenerate): Promise<void> => {
+export const command = async (options: Options, command: Command): Promise<void> => {
   const globalOptions = await getGlobalOptions(command);
 
-  const { verifyPaths, useMaintainers } = command;
+  const { verifyPaths, useMaintainers } = options;
 
-  const { output = globalOptions.output || OUTPUT } = command;
+  const { output = globalOptions.output || OUTPUT } = options;
 
   const loader = ora('generating codeowners...').start();
 


### PR DESCRIPTION
Fixes the code to work with [`commander` v7](https://github.com/tj/commander.js/blob/master/CHANGELOG.md) (related to https://github.com/gagoar/codeowners-generator/pull/162).

A breaking change is that the command and options have been split up. Example from their [changelog](https://github.com/tj/commander.js/blob/master/CHANGELOG.md):

```js
program
  .command('compress <filename>')
  .option('-t, --trace')
  // Old code before Commander 7
  .action((filename, cmd)) => {
    if (cmd.trace) console.log(`Command name is ${cmd.name()}`);
  });
```

```js
  // New code
  .action((filename, options, command)) => {
    if (options.trace) console.log(`Command name is ${command.name()}`);
  });
```