### PR TITLE
Fixing type issue introduced by commander fix

### DIFF
--- a/__tests__/generate.spec.ts
+++ b/__tests__/generate.spec.ts
@@ -93,7 +93,7 @@ describe('Generate', () => {
       callback(null, content);
     });
 
-    await generateCommand({ parent: {}, output: 'CODEOWNERS', groupSourceComments: true });
+    await generateCommand({ output: 'CODEOWNERS', groupSourceComments: true }, { parent: {} });
     expect(writeFile.mock.calls).toMatchInlineSnapshot(`
       Array [
         Array [

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -79,7 +79,7 @@ export const command = async (options: Options, command: Command): Promise<void>
 
   const loader = ora('generating codeowners...').start();
 
-  const groupSourceComments = globalOptions.groupSourceComments || command.groupSourceComments;
+  const groupSourceComments = globalOptions.groupSourceComments || options.groupSourceComments;
 
   debug('Options:', { ...globalOptions, useMaintainers, groupSourceComments, output });
 


### PR DESCRIPTION
## Description

When landing the commander v7 changes, turns out the types didn't match anymore with the new option added `groupSourceComments` 

