### PR TITLE
moving codeowners.spect.ts to __tests__

### DIFF
--- a/__tests__/codeowners.spec.ts
+++ b/__tests__/codeowners.spec.ts
@@ -1,8 +1,8 @@
-import { loadCodeOwnerFiles } from './codeowners';
-import { readContent } from './readContent';
+import { loadCodeOwnerFiles } from '../src/utils/codeowners';
+import { readContent } from '../src/utils/readContent';
 import { mocked } from 'ts-jest/utils';
 
-jest.mock('./readContent');
+jest.mock('../src/utils/readContent');
 
 const readContentMock = mocked(readContent);
 


### PR DESCRIPTION
## Description

I didn't notice before, but one of the new tests introduced was placed in `src/utils/` instead of `__tests__`

I prefer to keep all the tests grouped because when I navigate OSS projects, I often try to find the directory where tests are. This has been a great way to find out if the code has relevant tests, and learn how things are used inside the package/library.

cc @gustavkj 