### PR TITLE
removing warn from spec

### DIFF
--- a/__tests__/generate.spec.ts
+++ b/__tests__/generate.spec.ts
@@ -49,7 +49,6 @@ describe('Generate', () => {
     existsSync.mockReturnValue(true);
     readFile.mockImplementation((file: keyof typeof withPopulatedCodeownersFile, callback: Callback) => {
       const fullPath = path.join(__dirname, withPopulatedCodeownersFile[file]);
-      console.warn('mocked file', file, fullPath);
       const content = readFileSync(fullPath);
       callback(null, content);
     });


### PR DESCRIPTION
## Description

We were _annoyingly_ logging one mock helper in the tests. 

<img width="921" alt="Screen Shot 2021-01-24 at 2 29 14 PM" src="https://user-images.githubusercontent.com/226559/105645755-8bc0e000-5e50-11eb-913a-97abd8f12fdd.png">

It was left there by mistake. 