### PR TITLE
moving to esbuild

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1232,12 +1232,6 @@
         }
       }
     },
-    "@vercel/ncc": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.27.0.tgz",
-      "integrity": "sha512-DllIJQapnU2YwewIhh/4dYesmMQw3h2cFtabECc/zSJHqUbNa0eJuEkRa6DXbZvh1YPWBtYQoPV17NlDpBw1Vw==",
-      "dev": true
-    },
     "abab": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -2327,6 +2321,12 @@
       "requires": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "esbuild": {
+      "version": "0.8.34",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.8.34.tgz",
+      "integrity": "sha512-tnr0V1ooakYr1aRLXQLzCn2GVG1kBTW3FWpRyC+NgrR3ntsouVpJOlTOV0BS4YLATx3/c+x3h/uBq9lWJlUAtQ==",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -3,15 +3,15 @@
   "repository": "git@github.com:gagoar/codeowners-generator.git",
   "license": "MIT",
   "version": "1.4.0",
-  "description": " CODEOWNERS generator with mono repos",
+  "description": " CODEOWNERS generator for mono-repos",
   "main": "build/index.js",
   "bin": {
-    "codeowners-generator": "dist/index.js"
+    "codeowners-generator": "dist/cli.js"
   },
   "scripts": {
     "test": "jest",
-    "build-cli": "ncc build ./src/bin/cli.ts",
-    "build": "ncc build ./index.ts -o build",
+    "build-cli": "esbuild --bundle src/bin/cli.ts --platform=node --target=node12 --main-fields=main --outdir=dist/",
+    "build": "esbuild --bundle index.ts --platform=node --target=node12 --main-fields=main --outdir=build/",
     "lint": "eslint src/* --ext .ts",
     "version": "auto-changelog -p && git add CHANGELOG.md",
     "release": "npm run build && npm run build-cli && npm publish"
@@ -119,8 +119,8 @@
     "@types/parse-glob": "3.0.29",
     "@typescript-eslint/eslint-plugin": "4.14.0",
     "@typescript-eslint/parser": "4.14.0",
-    "@vercel/ncc": "0.27.0",
     "auto-changelog": "2.2.1",
+    "esbuild": "0.8.34",
     "eslint": "7.18.0",
     "eslint-config-prettier": "7.2.0",
     "husky": "4.3.8",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src", "test", "index.ts", "__tests__/codeowners.spec.ts"],
+  "include": ["src", "__tests__", "index.ts"],
   "compilerOptions": {
     "target": "es2017",
     "module": "es6",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src", "test", "index.ts"],
+  "include": ["src", "test", "index.ts", "__tests__/codeowners.spec.ts"],
   "compilerOptions": {
     "target": "es2017",
     "module": "es6",
@@ -23,9 +23,6 @@
     "resolveJsonModule": true,
     "experimentalDecorators": true,
     "baseUrl": "./",
-    "paths": {
-      "*": ["node_modules/*"]
-    },
     "jsx": "react",
     "esModuleInterop": true
   }


### PR DESCRIPTION
## Description

`@vercel/ncc` is quite unmaintained. and IMO losing relevance. Particularly because it uses Webpack in a really narrow way (what makes a really simple plug and play tool), making things hard when bugs show up.

 We had a bad experience when we discovered some issues while writing [use-herald-action](https://github.com/gagoar/use-herald-action) and since then we moved to `esbuild`. 

esbuild is also faster, and it only produces the bundle as a single file, instead of doing what ncc does today (it even pulls some tests types that are not needed)

