### PR TITLE
add leading slash to file patterns

### DIFF
--- a/__tests__/codeowners.spec.ts
+++ b/__tests__/codeowners.spec.ts
@@ -40,44 +40,44 @@ describe('Codeowners', () => {
     });
 
     const validRuleCases = [
-      ['should match * to all file under the given directory and its subdirectories', '*', 'dir1/**/*'],
+      ['should match * to all file under the given directory and its subdirectories', '*', '/dir1/**/*'],
       [
         'should only match /* to all file in the root of the given directory and not its subdirectories',
         '/*',
-        'dir1/*',
+        '/dir1/*',
       ],
-      ['should match *.ts to all ts file under the given directory and its subdirectories', '*.ts', 'dir1/**/*.ts'],
-      ['should only match /*.ts to ts file in the given directory and not its subdirectories', '/*.ts', 'dir1/*.ts'],
+      ['should match *.ts to all ts file under the given directory and its subdirectories', '*.ts', '/dir1/**/*.ts'],
+      ['should only match /*.ts to ts file in the given directory and not its subdirectories', '/*.ts', '/dir1/*.ts'],
       [
         'should match apps/ to any directories named apps in the given directory and its subdirectories',
         'apps/',
-        'dir1/**/apps/',
+        '/dir1/**/apps/',
       ],
       [
         'should match docs/* to files under directly inside a directory named docs in the given directory',
         'docs/*',
-        'dir1/docs/*',
+        '/dir1/docs/*',
       ],
       [
         'should match filenames to files in the given directory and its subdirectories',
         'README.md',
-        'dir1/**/README.md',
+        '/dir1/**/README.md',
       ],
-      ['should append globstar patterns to the given directory', '**/something.ts', 'dir1/**/something.ts'],
-      ['should append globstar/glob patterns to the given directory', '**/*.ts', 'dir1/**/*.ts'],
-      ['should append glob patterns with fixed base to the given directory', 'dir2/*.ts', 'dir1/dir2/*.ts'],
-      ['should append static file patterns to the given directory', 'dir2/something.ts', 'dir1/dir2/something.ts'],
-      ['should append static directory patterns (dir2/dir3/) to the given directory', 'dir2/dir3/', 'dir1/dir2/dir3/'],
-      ['should append patterns starting with a slash (/) to the given directory', '/', 'dir1/'],
+      ['should append globstar patterns to the given directory', '**/something.ts', '/dir1/**/something.ts'],
+      ['should append globstar/glob patterns to the given directory', '**/*.ts', '/dir1/**/*.ts'],
+      ['should append glob patterns with fixed base to the given directory', 'dir2/*.ts', '/dir1/dir2/*.ts'],
+      ['should append static file patterns to the given directory', 'dir2/something.ts', '/dir1/dir2/something.ts'],
+      ['should append static directory patterns (dir2/dir3/) to the given directory', 'dir2/dir3/', '/dir1/dir2/dir3/'],
+      ['should append patterns starting with a slash (/) to the given directory', '/', '/dir1/'],
       [
         'should append file patterns starting with a slash (/asd/asd.ts) to the given directory',
         '/asd/asd.ts',
-        'dir1/asd/asd.ts',
+        '/dir1/asd/asd.ts',
       ],
       [
         'should append glob patterns starting with a slash (/**/asd.ts) to the given directory',
         '/**/asd.ts',
-        'dir1/**/asd.ts',
+        '/dir1/**/asd.ts',
       ],
     ];
 

--- a/__tests__/generate.spec.ts
+++ b/__tests__/generate.spec.ts
@@ -68,23 +68,23 @@ describe('Generate', () => {
       # To re-generate, run \`yarn codeowners-generator generate\`. Don't worry, the content outside this block will be kept.
 
       # Rule extracted from dir1/CODEOWNERS
-      dir1/**/*.ts @eeny @meeny
+      /dir1/**/*.ts @eeny @meeny
       # Rule extracted from dir1/CODEOWNERS
-      dir1/*.ts @miny
+      /dir1/*.ts @miny
       # Rule extracted from dir1/CODEOWNERS
-      dir1/**/README.md @miny
+      /dir1/**/README.md @miny
       # Rule extracted from dir1/CODEOWNERS
-      dir1/README.md @moe
+      /dir1/README.md @moe
       # Rule extracted from dir2/CODEOWNERS
-      dir2/**/*.ts @moe
+      /dir2/**/*.ts @moe
       # Rule extracted from dir2/CODEOWNERS
-      dir2/dir3/*.ts @miny
+      /dir2/dir3/*.ts @miny
       # Rule extracted from dir2/CODEOWNERS
-      dir2/**/*.md @meeny
+      /dir2/**/*.md @meeny
       # Rule extracted from dir2/CODEOWNERS
-      dir2/**/dir4/ @eeny
+      /dir2/**/dir4/ @eeny
       # Rule extracted from dir2/dir3/CODEOWNERS
-      dir2/dir3/**/*.ts @miny
+      /dir2/dir3/**/*.ts @miny
 
       #################################### Generated content - do not edit! ####################################",
       ]
@@ -110,17 +110,17 @@ describe('Generate', () => {
       # To re-generate, run \`npm run codeowners-generator generate\`. Don't worry, the content outside this block will be kept.
 
       # Rules extracted from dir1/CODEOWNERS
-      dir1/**/*.ts @eeny @meeny
-      dir1/*.ts @miny
-      dir1/**/README.md @miny
-      dir1/README.md @moe
+      /dir1/**/*.ts @eeny @meeny
+      /dir1/*.ts @miny
+      /dir1/**/README.md @miny
+      /dir1/README.md @moe
       # Rules extracted from dir2/CODEOWNERS
-      dir2/**/*.ts @moe
-      dir2/dir3/*.ts @miny
-      dir2/**/*.md @meeny 
-      dir2/**/dir4/ @eeny
+      /dir2/**/*.ts @moe
+      /dir2/dir3/*.ts @miny
+      /dir2/**/*.md @meeny 
+      /dir2/**/dir4/ @eeny
       # Rule extracted from dir2/dir3/CODEOWNERS
-      dir2/dir3/**/*.ts @miny
+      /dir2/dir3/**/*.ts @miny
 
       #################################### Generated content - do not edit! ####################################",
         ],
@@ -147,23 +147,23 @@ describe('Generate', () => {
       # To re-generate, run \`npm run codeowners-generator generate\`. Don't worry, the content outside this block will be kept.
 
       # Rule extracted from dir1/CODEOWNERS
-      dir1/**/*.ts @eeny @meeny
+      /dir1/**/*.ts @eeny @meeny
       # Rule extracted from dir1/CODEOWNERS
-      dir1/*.ts @miny
+      /dir1/*.ts @miny
       # Rule extracted from dir1/CODEOWNERS
-      dir1/**/README.md @miny
+      /dir1/**/README.md @miny
       # Rule extracted from dir1/CODEOWNERS
-      dir1/README.md @moe
+      /dir1/README.md @moe
       # Rule extracted from dir2/CODEOWNERS
-      dir2/**/*.ts @moe
+      /dir2/**/*.ts @moe
       # Rule extracted from dir2/CODEOWNERS
-      dir2/dir3/*.ts @miny
+      /dir2/dir3/*.ts @miny
       # Rule extracted from dir2/CODEOWNERS
-      dir2/**/*.md @meeny
+      /dir2/**/*.md @meeny
       # Rule extracted from dir2/CODEOWNERS
-      dir2/**/dir4/ @eeny
+      /dir2/**/dir4/ @eeny
       # Rule extracted from dir2/dir3/CODEOWNERS
-      dir2/dir3/**/*.ts @miny
+      /dir2/dir3/**/*.ts @miny
 
       #################################### Generated content - do not edit! ####################################",
         ],
@@ -209,29 +209,29 @@ describe('Generate', () => {
       # To re-generate, run \`npm run codeowners-generator generate\`. Don't worry, the content outside this block will be kept.
 
       # Rule extracted from dir5/package.json
-      dir5/ friend@example.com other@example.com
+      /dir5/ friend@example.com other@example.com
       # Rule extracted from dir2/dir1/package.json
-      dir2/dir1/ friend@example.com other@example.com
+      /dir2/dir1/ friend@example.com other@example.com
       # Rule extracted from dir8/package.json
-      dir8/ gbuilder@builder.com other.friend@domain.com
+      /dir8/ gbuilder@builder.com other.friend@domain.com
       # Rule extracted from dir1/CODEOWNERS
-      dir1/**/*.ts @eeny @meeny
+      /dir1/**/*.ts @eeny @meeny
       # Rule extracted from dir1/CODEOWNERS
-      dir1/*.ts @miny
+      /dir1/*.ts @miny
       # Rule extracted from dir1/CODEOWNERS
-      dir1/**/README.md @miny
+      /dir1/**/README.md @miny
       # Rule extracted from dir1/CODEOWNERS
-      dir1/README.md @moe
+      /dir1/README.md @moe
       # Rule extracted from dir2/CODEOWNERS
-      dir2/**/*.ts @moe
+      /dir2/**/*.ts @moe
       # Rule extracted from dir2/CODEOWNERS
-      dir2/dir3/*.ts @miny
+      /dir2/dir3/*.ts @miny
       # Rule extracted from dir2/CODEOWNERS
-      dir2/**/*.md @meeny
+      /dir2/**/*.md @meeny
       # Rule extracted from dir2/CODEOWNERS
-      dir2/**/dir4/ @eeny
+      /dir2/**/dir4/ @eeny
       # Rule extracted from dir2/dir3/CODEOWNERS
-      dir2/dir3/**/*.ts @miny
+      /dir2/dir3/**/*.ts @miny
 
       #################################### Generated content - do not edit! ####################################"
     `);
@@ -275,21 +275,21 @@ describe('Generate', () => {
       # To re-generate, run \`npm run codeowners-generator generate\`. Don't worry, the content outside this block will be kept.
 
       # Rule extracted from dir5/package.json
-      dir5/ friend@example.com other@example.com
+      /dir5/ friend@example.com other@example.com
       # Rule extracted from dir2/dir1/package.json
-      dir2/dir1/ friend@example.com other@example.com
+      /dir2/dir1/ friend@example.com other@example.com
       # Rules extracted from dir1/CODEOWNERS
-      dir1/**/*.ts @eeny @meeny
-      dir1/*.ts @miny
-      dir1/**/README.md @miny
-      dir1/README.md @moe
+      /dir1/**/*.ts @eeny @meeny
+      /dir1/*.ts @miny
+      /dir1/**/README.md @miny
+      /dir1/README.md @moe
       # Rules extracted from dir2/CODEOWNERS
-      dir2/**/*.ts @moe
-      dir2/dir3/*.ts @miny
-      dir2/**/*.md @meeny 
-      dir2/**/dir4/ @eeny
+      /dir2/**/*.ts @moe
+      /dir2/dir3/*.ts @miny
+      /dir2/**/*.md @meeny 
+      /dir2/**/dir4/ @eeny
       # Rule extracted from dir2/dir3/CODEOWNERS
-      dir2/dir3/**/*.ts @miny
+      /dir2/dir3/**/*.ts @miny
 
       #################################### Generated content - do not edit! ####################################"
     `);
@@ -325,31 +325,31 @@ describe('Generate', () => {
       # To re-generate, run \`npm run codeowners-generator generate\`. Don't worry, the content outside this block will be kept.
 
       # Rule extracted from dir5/package.json
-      dir5/ friend@example.com other@example.com
+      /dir5/ friend@example.com other@example.com
       # Rule extracted from dir2/dir1/package.json
-      dir2/dir1/ friend@example.com other@example.com
+      /dir2/dir1/ friend@example.com other@example.com
       # Rule extracted from dir5/package.json
-      dir5/ friend@example.com other@example.com
+      /dir5/ friend@example.com other@example.com
       # Rule extracted from dir2/dir1/package.json
-      dir2/dir1/ friend@example.com other@example.com
+      /dir2/dir1/ friend@example.com other@example.com
       # Rule extracted from dir1/CODEOWNERS
-      dir1/**/*.ts @eeny @meeny
+      /dir1/**/*.ts @eeny @meeny
       # Rule extracted from dir1/CODEOWNERS
-      dir1/*.ts @miny
+      /dir1/*.ts @miny
       # Rule extracted from dir1/CODEOWNERS
-      dir1/**/README.md @miny
+      /dir1/**/README.md @miny
       # Rule extracted from dir1/CODEOWNERS
-      dir1/README.md @moe
+      /dir1/README.md @moe
       # Rule extracted from dir2/CODEOWNERS
-      dir2/**/*.ts @moe
+      /dir2/**/*.ts @moe
       # Rule extracted from dir2/CODEOWNERS
-      dir2/dir3/*.ts @miny
+      /dir2/dir3/*.ts @miny
       # Rule extracted from dir2/CODEOWNERS
-      dir2/**/*.md @meeny
+      /dir2/**/*.md @meeny
       # Rule extracted from dir2/CODEOWNERS
-      dir2/**/dir4/ @eeny
+      /dir2/**/dir4/ @eeny
       # Rule extracted from dir2/dir3/CODEOWNERS
-      dir2/dir3/**/*.ts @miny
+      /dir2/dir3/**/*.ts @miny
 
       #################################### Generated content - do not edit! ####################################"
     `);
@@ -372,7 +372,7 @@ describe('Generate', () => {
       Array [
         Object {
           "filePath": "dir1/CODEOWNERS",
-          "glob": "dir1/**/*.ts",
+          "glob": "/dir1/**/*.ts",
           "owners": Array [
             "@eeny",
             "@meeny",
@@ -380,42 +380,42 @@ describe('Generate', () => {
         },
         Object {
           "filePath": "dir1/CODEOWNERS",
-          "glob": "dir1/*.ts",
+          "glob": "/dir1/*.ts",
           "owners": Array [
             "@miny",
           ],
         },
         Object {
           "filePath": "dir1/CODEOWNERS",
-          "glob": "dir1/**/README.md",
+          "glob": "/dir1/**/README.md",
           "owners": Array [
             "@miny",
           ],
         },
         Object {
           "filePath": "dir1/CODEOWNERS",
-          "glob": "dir1/README.md",
+          "glob": "/dir1/README.md",
           "owners": Array [
             "@moe",
           ],
         },
         Object {
           "filePath": "dir2/CODEOWNERS",
-          "glob": "dir2/**/*.ts",
+          "glob": "/dir2/**/*.ts",
           "owners": Array [
             "@moe",
           ],
         },
         Object {
           "filePath": "dir2/CODEOWNERS",
-          "glob": "dir2/dir3/*.ts",
+          "glob": "/dir2/dir3/*.ts",
           "owners": Array [
             "@miny",
           ],
         },
         Object {
           "filePath": "dir2/CODEOWNERS",
-          "glob": "dir2/**/*.md",
+          "glob": "/dir2/**/*.md",
           "owners": Array [
             "@meeny",
             "",
@@ -423,14 +423,14 @@ describe('Generate', () => {
         },
         Object {
           "filePath": "dir2/CODEOWNERS",
-          "glob": "dir2/**/dir4/",
+          "glob": "/dir2/**/dir4/",
           "owners": Array [
             "@eeny",
           ],
         },
         Object {
           "filePath": "dir2/dir3/CODEOWNERS",
-          "glob": "dir2/dir3/**/*.ts",
+          "glob": "/dir2/dir3/**/*.ts",
           "owners": Array [
             "@miny",
           ],

--- a/src/utils/codeowners.ts
+++ b/src/utils/codeowners.ts
@@ -141,7 +141,7 @@ const createMatcherCodeownersRule = (filePath: string, rule: string) => {
 
   if (owners.length && isValidCodeownersGlob(glob)) {
     return {
-      glob: join(dirname(filePath), translateGlob(glob)),
+      glob: join('/', dirname(filePath), translateGlob(glob)),
       owners,
     };
   } else {
@@ -198,7 +198,7 @@ const getOwnersFromMaintainerField = (filePath: string, content: string): ownerR
 
       return {
         filePath,
-        glob: `${dirname(filePath)}/`,
+        glob: join('/', dirname(filePath), '/'),
         owners,
       };
     } else {


### PR DESCRIPTION
This PR adds leading slashes to paths in order to avoid accidentally matching all directories of a given name (e.g. `apps/` would match all directories named `apps`).

It is a follow up based on this comment: https://github.com/gagoar/codeowners-generator/issues/160#issuecomment-764485896