### PR TITLE
Add customRegenerationCommand to specify the printed re-generate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ You can configure `codeowners-generator` from several places:
 
 - **groupSourceComments** (`--group-source-comments`): Instead of generating one comment per rule, enabling this flag will group them, reducing comments to one per source file. Useful if your codeowners file gets too noisy.
 
+- **customRegenerationCommand** (`--custom-regeneration-command`): Specify a custom regeneration command to be printed in the generated CODEOWNERS file, it should be mapped to run codeowners-generator (e.g. "npm run codeowners").
+
 For more details you can invoke:
 
 ```sh
@@ -137,7 +139,8 @@ You can also define custom configuration in your package:
     "includes": ["**/CODEOWNERS"],
     "output": ".github/CODEOWNERS",
     "useMaintainers": true,
-    "groupSourceComments": true
+    "groupSourceComments": true,
+    "customRegenerationCommand": "npm run codeowners"
   },
   "scripts": {
     "codeowners": " codeowners-generator generate"

--- a/__tests__/generate.spec.ts
+++ b/__tests__/generate.spec.ts
@@ -64,8 +64,8 @@ describe('Generate', () => {
 
 
       #################################### Generated content - do not edit! ####################################
-      # This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator/README.md)
-      # To re-generate, run \`yarn codeowners-generator generate\`. Don't worry, the content outside this block will be kept.
+      # This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator)
+      # Don't worry, the content outside this block will be kept.
 
       # Rule extracted from dir1/CODEOWNERS
       dir1/**/*.ts @eeny @meeny
@@ -106,8 +106,8 @@ describe('Generate', () => {
         Array [
           "CODEOWNERS",
           "#################################### Generated content - do not edit! ####################################
-      # This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator/README.md)
-      # To re-generate, run \`npm run codeowners-generator generate\`. Don't worry, the content outside this block will be kept.
+      # This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator)
+      # Don't worry, the content outside this block will be kept.
 
       # Rules extracted from dir1/CODEOWNERS
       dir1/**/*.ts @eeny @meeny
@@ -143,8 +143,8 @@ describe('Generate', () => {
         Array [
           "CODEOWNERS",
           "#################################### Generated content - do not edit! ####################################
-      # This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator/README.md)
-      # To re-generate, run \`npm run codeowners-generator generate\`. Don't worry, the content outside this block will be kept.
+      # This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator)
+      # Don't worry, the content outside this block will be kept.
 
       # Rule extracted from dir1/CODEOWNERS
       dir1/**/*.ts @eeny @meeny
@@ -205,8 +205,8 @@ describe('Generate', () => {
     expect(search).toHaveBeenCalled();
     expect(writeFile.mock.calls[0][1]).toMatchInlineSnapshot(`
       "#################################### Generated content - do not edit! ####################################
-      # This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator/README.md)
-      # To re-generate, run \`npm run codeowners-generator generate\`. Don't worry, the content outside this block will be kept.
+      # This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator)
+      # Don't worry, the content outside this block will be kept.
 
       # Rule extracted from dir5/package.json
       dir5/ friend@example.com other@example.com
@@ -271,8 +271,66 @@ describe('Generate', () => {
     expect(search).toHaveBeenCalled();
     expect(writeFile.mock.calls[0][1]).toMatchInlineSnapshot(`
       "#################################### Generated content - do not edit! ####################################
-      # This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator/README.md)
-      # To re-generate, run \`npm run codeowners-generator generate\`. Don't worry, the content outside this block will be kept.
+      # This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator)
+      # Don't worry, the content outside this block will be kept.
+
+      # Rule extracted from dir5/package.json
+      dir5/ friend@example.com other@example.com
+      # Rule extracted from dir2/dir1/package.json
+      dir2/dir1/ friend@example.com other@example.com
+      # Rules extracted from dir1/CODEOWNERS
+      dir1/**/*.ts @eeny @meeny
+      dir1/*.ts @miny
+      dir1/**/README.md @miny
+      dir1/README.md @moe
+      # Rules extracted from dir2/CODEOWNERS
+      dir2/**/*.ts @moe
+      dir2/dir3/*.ts @miny
+      dir2/**/*.md @meeny 
+      dir2/**/dir4/ @eeny
+      # Rule extracted from dir2/dir3/CODEOWNERS
+      dir2/dir3/**/*.ts @miny
+
+      #################################### Generated content - do not edit! ####################################"
+    `);
+  });
+  it('should generate a CODEOWNERS FILE with package.maintainers field and customCommand using cosmiconfig', async () => {
+    search.mockImplementationOnce(() =>
+      Promise.resolve({
+        isEmpty: false,
+        filepath: '/some/package.json',
+        config: {
+          output: '.github/CODEOWNERS',
+          useMaintainers: true,
+          groupSourceComments: true,
+          includes: ['dir1/*', 'dir2/*', 'dir5/*', 'dir6/*', 'dir7/*'],
+        },
+      })
+    );
+
+    const packageFiles = {
+      ...files,
+      'dir5/package.json': '../__mocks__/package1.json',
+      'dir2/dir1/package.json': '../__mocks__/package2.json',
+      'dir6/package.json': '../__mocks__/package3.json',
+      'dir7/package.json': '../__mocks__/package4.json',
+    };
+
+    sync.mockReturnValueOnce(Object.keys(packageFiles));
+
+    sync.mockReturnValueOnce(['.gitignore']);
+    const withAddedPackageFiles = { ...packageFiles, ...withGitIgnore };
+    readFile.mockImplementation((file: keyof typeof withAddedPackageFiles, callback: Callback) => {
+      const content = readFileSync(path.join(__dirname, withAddedPackageFiles[file]));
+      callback(null, content);
+    });
+
+    await generateCommand({ customCommand: 'generate-codeowners' }, { parent: {} });
+    expect(search).toHaveBeenCalled();
+    expect(writeFile.mock.calls[0][1]).toMatchInlineSnapshot(`
+      "#################################### Generated content - do not edit! ####################################
+      # This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator)
+      # To re-generate, run \`npm run generate-codeowners\`. Don't worry, the content outside this block will be kept.
 
       # Rule extracted from dir5/package.json
       dir5/ friend@example.com other@example.com
@@ -321,8 +379,8 @@ describe('Generate', () => {
     await generateCommand({ output: 'CODEOWNERS', useMaintainers: true }, { parent: {} });
     expect(writeFile.mock.calls[0][1]).toMatchInlineSnapshot(`
       "#################################### Generated content - do not edit! ####################################
-      # This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator/README.md)
-      # To re-generate, run \`npm run codeowners-generator generate\`. Don't worry, the content outside this block will be kept.
+      # This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator)
+      # Don't worry, the content outside this block will be kept.
 
       # Rule extracted from dir5/package.json
       dir5/ friend@example.com other@example.com

--- a/__tests__/generate.spec.ts
+++ b/__tests__/generate.spec.ts
@@ -275,21 +275,21 @@ describe('Generate', () => {
       # Don't worry, the content outside this block will be kept.
 
       # Rule extracted from dir5/package.json
-      dir5/ friend@example.com other@example.com
+      /dir5/ friend@example.com other@example.com
       # Rule extracted from dir2/dir1/package.json
-      dir2/dir1/ friend@example.com other@example.com
+      /dir2/dir1/ friend@example.com other@example.com
       # Rules extracted from dir1/CODEOWNERS
-      dir1/**/*.ts @eeny @meeny
-      dir1/*.ts @miny
-      dir1/**/README.md @miny
-      dir1/README.md @moe
+      /dir1/**/*.ts @eeny @meeny
+      /dir1/*.ts @miny
+      /dir1/**/README.md @miny
+      /dir1/README.md @moe
       # Rules extracted from dir2/CODEOWNERS
-      dir2/**/*.ts @moe
-      dir2/dir3/*.ts @miny
-      dir2/**/*.md @meeny 
-      dir2/**/dir4/ @eeny
+      /dir2/**/*.ts @moe
+      /dir2/dir3/*.ts @miny
+      /dir2/**/*.md @meeny 
+      /dir2/**/dir4/ @eeny
       # Rule extracted from dir2/dir3/CODEOWNERS
-      dir2/dir3/**/*.ts @miny
+      /dir2/dir3/**/*.ts @miny
 
       #################################### Generated content - do not edit! ####################################"
     `);

--- a/__tests__/generate.spec.ts
+++ b/__tests__/generate.spec.ts
@@ -294,7 +294,7 @@ describe('Generate', () => {
       #################################### Generated content - do not edit! ####################################"
     `);
   });
-  it('should generate a CODEOWNERS FILE with package.maintainers field and customCommand using cosmiconfig', async () => {
+  it('should generate a CODEOWNERS FILE with package.maintainers field and customRegenerationCommand using cosmiconfig', async () => {
     search.mockImplementationOnce(() =>
       Promise.resolve({
         isEmpty: false,

--- a/__tests__/generate.spec.ts
+++ b/__tests__/generate.spec.ts
@@ -325,12 +325,12 @@ describe('Generate', () => {
       callback(null, content);
     });
 
-    await generateCommand({ customCommand: 'generate-codeowners' }, { parent: {} });
+    await generateCommand({ customRegenerationCommand: 'npx codeowners-generator generate' }, { parent: {} });
     expect(search).toHaveBeenCalled();
     expect(writeFile.mock.calls[0][1]).toMatchInlineSnapshot(`
       "#################################### Generated content - do not edit! ####################################
       # This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator)
-      # To re-generate, run \`npm run generate-codeowners\`. Don't worry, the content outside this block will be kept.
+      # To re-generate, run \`npx codeowners-generator generate\`. Don't worry, the content outside this block will be kept.
 
       # Rule extracted from dir5/package.json
       /dir5/ friend@example.com other@example.com

--- a/__tests__/generate.spec.ts
+++ b/__tests__/generate.spec.ts
@@ -53,7 +53,10 @@ describe('Generate', () => {
       callback(null, content);
     });
 
-    await generateCommand({ output: 'CODEOWNERS' }, { parent: {} });
+    await generateCommand(
+      { output: 'CODEOWNERS', customRegenerationCommand: 'yarn codeowners-generator generate' },
+      { parent: {} }
+    );
     expect(writeFile.mock.calls[0]).toMatchInlineSnapshot(`
       Array [
         "CODEOWNERS",
@@ -65,7 +68,7 @@ describe('Generate', () => {
 
       #################################### Generated content - do not edit! ####################################
       # This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator)
-      # Don't worry, the content outside this block will be kept.
+      # To re-generate, run \`yarn codeowners-generator generate\`. Don't worry, the content outside this block will be kept.
 
       # Rule extracted from dir1/CODEOWNERS
       /dir1/**/*.ts @eeny @meeny
@@ -90,7 +93,7 @@ describe('Generate', () => {
       ]
     `);
   });
-  it('should generate a CODEOWNERS FILE with groupSourceComments', async () => {
+  it('should generate a CODEOWNERS FILE with groupSourceComments and customRegenerationCommand', async () => {
     sync.mockReturnValueOnce(Object.keys(files));
 
     sync.mockReturnValueOnce(['.gitignore']);
@@ -100,14 +103,21 @@ describe('Generate', () => {
       callback(null, content);
     });
 
-    await generateCommand({ output: 'CODEOWNERS', groupSourceComments: true }, { parent: {} });
+    await generateCommand(
+      {
+        output: 'CODEOWNERS',
+        groupSourceComments: true,
+        customRegenerationCommand: 'npm run codeowners-generator generate',
+      },
+      { parent: {} }
+    );
     expect(writeFile.mock.calls).toMatchInlineSnapshot(`
       Array [
         Array [
           "CODEOWNERS",
           "#################################### Generated content - do not edit! ####################################
       # This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator)
-      # Don't worry, the content outside this block will be kept.
+      # To re-generate, run \`npm run codeowners-generator generate\`. Don't worry, the content outside this block will be kept.
 
       # Rules extracted from dir1/CODEOWNERS
       /dir1/**/*.ts @eeny @meeny

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -25,8 +25,8 @@ program
     false
   )
   .option(
-    '--custom-command',
-    'Specify a custom command which will run codeowners-generator and should be printed in the generated file.'
+    '--custom-regeneration-command',
+    'Specify a custom regeneration command which will run codeowners-generator and should be printed in the generated file.'
   )
   .option('--output [output file]', 'The output path and name of the file, (default: CODEOWNERS)')
   .action(generateCommand);

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -26,7 +26,7 @@ program
   )
   .option(
     '--custom-regeneration-command',
-    'Specify a custom regeneration command which will run codeowners-generator and should be printed in the generated file.'
+    'Specify a custom regeneration command to be printed in the generated CODEOWNERS file, it should be mapped to run codeowners-generator'
   )
   .option('--output [output file]', 'The output path and name of the file, (default: CODEOWNERS)')
   .action(generateCommand);

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -24,6 +24,10 @@ program
     'Instead of generating one comment per rule, enabling this flag will group them, reducing comments to one per source file. Useful if your codeowners file gets too noisy',
     false
   )
+  .option(
+    '--custom-command',
+    'Specify a custom command which will run codeowners-generator and should be printed in the generated file.'
+  )
   .option('--output [output file]', 'The output path and name of the file, (default: CODEOWNERS)')
   .action(generateCommand);
 

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -68,7 +68,7 @@ interface Options {
   useMaintainers?: boolean;
   groupSourceComments?: boolean;
   includes?: string[];
-  customCommand?: string;
+  customRegenerationCommand?: string;
 }
 
 export const command = async (options: Options, command: Command): Promise<void> => {
@@ -82,7 +82,7 @@ export const command = async (options: Options, command: Command): Promise<void>
 
   const groupSourceComments = globalOptions.groupSourceComments || options.groupSourceComments;
 
-  const customCommand = globalOptions.customCommand || options.customCommand;
+  const customCommand = globalOptions.customRegenerationCommand || options.customRegenerationCommand;
 
   debug('Options:', { ...globalOptions, useMaintainers, groupSourceComments, customCommand, output });
 

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -68,6 +68,7 @@ interface Options {
   useMaintainers?: boolean;
   groupSourceComments?: boolean;
   includes?: string[];
+  customCommand?: string;
 }
 
 export const command = async (options: Options, command: Command): Promise<void> => {
@@ -81,13 +82,15 @@ export const command = async (options: Options, command: Command): Promise<void>
 
   const groupSourceComments = globalOptions.groupSourceComments || options.groupSourceComments;
 
-  debug('Options:', { ...globalOptions, useMaintainers, groupSourceComments, output });
+  const customCommand = globalOptions.customCommand || options.customCommand;
+
+  debug('Options:', { ...globalOptions, useMaintainers, groupSourceComments, customCommand, output });
 
   try {
     const ownerRules = await generate({ rootDir: __dirname, verifyPaths, useMaintainers, ...globalOptions });
 
     if (ownerRules.length) {
-      await createOwnersFile(output, ownerRules, groupSourceComments);
+      await createOwnersFile(output, ownerRules, groupSourceComments, customCommand);
 
       loader.stopAndPersist({ text: `CODEOWNERS file was created! location: ${output}`, symbol: SUCCESS_SYMBOL });
     } else {

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -90,7 +90,7 @@ export const command = async (options: Options, command: Command): Promise<void>
     const ownerRules = await generate({ rootDir: __dirname, verifyPaths, useMaintainers, ...globalOptions });
 
     if (ownerRules.length) {
-      await createOwnersFile(output, ownerRules, groupSourceComments, customRegenerationCommand);
+      await createOwnersFile(output, ownerRules, customRegenerationCommand, groupSourceComments);
 
       loader.stopAndPersist({ text: `CODEOWNERS file was created! location: ${output}`, symbol: SUCCESS_SYMBOL });
     } else {

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -82,15 +82,15 @@ export const command = async (options: Options, command: Command): Promise<void>
 
   const groupSourceComments = globalOptions.groupSourceComments || options.groupSourceComments;
 
-  const customCommand = globalOptions.customRegenerationCommand || options.customRegenerationCommand;
+  const customRegenerationCommand = globalOptions.customRegenerationCommand || options.customRegenerationCommand;
 
-  debug('Options:', { ...globalOptions, useMaintainers, groupSourceComments, customCommand, output });
+  debug('Options:', { ...globalOptions, useMaintainers, groupSourceComments, customRegenerationCommand, output });
 
   try {
     const ownerRules = await generate({ rootDir: __dirname, verifyPaths, useMaintainers, ...globalOptions });
 
     if (ownerRules.length) {
-      await createOwnersFile(output, ownerRules, groupSourceComments, customCommand);
+      await createOwnersFile(output, ownerRules, groupSourceComments, customRegenerationCommand);
 
       loader.stopAndPersist({ text: `CODEOWNERS file was created! location: ${output}`, symbol: SUCCESS_SYMBOL });
     } else {

--- a/src/utils/codeowners.ts
+++ b/src/utils/codeowners.ts
@@ -44,7 +44,8 @@ const filterGeneratedContent = (content: string) => {
 export const createOwnersFile = async (
   outputFile: string,
   ownerRules: ownerRule[],
-  groupSourceComments = false
+  groupSourceComments = false,
+  customCommand: string | undefined = undefined
 ): Promise<void> => {
   let originalContent = '';
 
@@ -67,7 +68,7 @@ export const createOwnersFile = async (
     content = ownerRules.map((rule) => rulesBlockTemplate(rule.filePath, [`${rule.glob} ${rule.owners.join(' ')}`]));
   }
 
-  fs.writeFileSync(outputFile, contentTemplate(content.join('\n'), originalContent));
+  fs.writeFileSync(outputFile, contentTemplate(content.join('\n'), originalContent, customCommand));
 };
 
 const parseCodeOwner = (filePath: string, codeOwnerContent: string): ownerRule[] => {

--- a/src/utils/codeowners.ts
+++ b/src/utils/codeowners.ts
@@ -45,7 +45,7 @@ export const createOwnersFile = async (
   outputFile: string,
   ownerRules: ownerRule[],
   groupSourceComments = false,
-  customCommand: string | undefined = undefined
+  customRegenerationCommand: string | undefined = undefined
 ): Promise<void> => {
   let originalContent = '';
 
@@ -68,7 +68,7 @@ export const createOwnersFile = async (
     content = ownerRules.map((rule) => rulesBlockTemplate(rule.filePath, [`${rule.glob} ${rule.owners.join(' ')}`]));
   }
 
-  fs.writeFileSync(outputFile, contentTemplate(content.join('\n'), originalContent, customCommand));
+  fs.writeFileSync(outputFile, contentTemplate(content.join('\n'), originalContent, customRegenerationCommand));
 };
 
 const parseCodeOwner = (filePath: string, codeOwnerContent: string): ownerRule[] => {

--- a/src/utils/codeowners.ts
+++ b/src/utils/codeowners.ts
@@ -44,8 +44,8 @@ const filterGeneratedContent = (content: string) => {
 export const createOwnersFile = async (
   outputFile: string,
   ownerRules: ownerRule[],
-  groupSourceComments = false,
-  customRegenerationCommand: string | undefined = undefined
+  customRegenerationCommand?: string,
+  groupSourceComments = false
 ): Promise<void> => {
   let originalContent = '';
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -12,22 +12,21 @@ export const CHARACTER_RANGE_PATTERN = /\[(?:.-.)+\]/;
 export const CONTENT_MARK = stripIndents`
 #################################### Generated content - do not edit! ####################################
 `;
-const CONTENT_LEGEND_NPM = stripIndents`
-# This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator/README.md)
-# To re-generate, run \`npm run codeowners-generator generate\`. Don't worry, the content outside this block will be kept. 
-`;
-const CONTENT_LEGEND_YARN = stripIndents`
-# This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator/README.md)
-# To re-generate, run \`yarn codeowners-generator generate\`. Don't worry, the content outside this block will be kept. 
+
+const isYarn = () => existsSync('./yarn.lock');
+
+const getContentLegend = (customCommand?: string) => stripIndents`
+# This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator)
+# ${
+  customCommand ? `To re-generate, run \`${isYarn() ? 'yarn' : 'npm run'} ${customCommand}\`. ` : ''
+}Don't worry, the content outside this block will be kept. 
 `;
 
-const getContentLegend = () => (existsSync('./yarn.lock') ? CONTENT_LEGEND_YARN : CONTENT_LEGEND_NPM);
-
-export const contentTemplate = (generatedContent: string, originalContent: string): string => {
+export const contentTemplate = (generatedContent: string, originalContent: string, customCommand?: string): string => {
   return stripIndents`
   ${originalContent && originalContent}
   ${CONTENT_MARK}
-  ${getContentLegend()}\n
+  ${getContentLegend(customCommand)}\n
   ${generatedContent}\n
   ${CONTENT_MARK}\n
 `;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,5 +1,4 @@
 import { stripIndents } from 'common-tags';
-import { existsSync } from 'fs';
 export const SUCCESS_SYMBOL = '💫';
 export const SHRUG_SYMBOL = '¯\\_(ツ)_/¯';
 export const OUTPUT = 'CODEOWNERS';
@@ -13,20 +12,22 @@ export const CONTENT_MARK = stripIndents`
 #################################### Generated content - do not edit! ####################################
 `;
 
-const isYarn = () => existsSync('./yarn.lock');
-
-const getContentLegend = (customCommand?: string) => stripIndents`
+const getContentLegend = (customRegenerationCommand?: string) => stripIndents`
 # This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator)
 # ${
-  customCommand ? `To re-generate, run \`${isYarn() ? 'yarn' : 'npm run'} ${customCommand}\`. ` : ''
+  customRegenerationCommand ? `To re-generate, run \`${customRegenerationCommand}\`. ` : ''
 }Don't worry, the content outside this block will be kept. 
 `;
 
-export const contentTemplate = (generatedContent: string, originalContent: string, customCommand?: string): string => {
+export const contentTemplate = (
+  generatedContent: string,
+  originalContent: string,
+  customRegenerationCommand?: string
+): string => {
   return stripIndents`
   ${originalContent && originalContent}
   ${CONTENT_MARK}
-  ${getContentLegend(customCommand)}\n
+  ${getContentLegend(customRegenerationCommand)}\n
   ${generatedContent}\n
   ${CONTENT_MARK}\n
 `;

--- a/src/utils/getCustomConfiguration.ts
+++ b/src/utils/getCustomConfiguration.ts
@@ -11,7 +11,7 @@ export type CustomConfig = {
   useMaintainers?: boolean;
   groupSourceComments?: boolean;
   output?: string;
-  customCommand?: string;
+  customRegenerationCommand?: string;
 };
 
 export const getCustomConfiguration = async (): Promise<CustomConfig | void> => {

--- a/src/utils/getCustomConfiguration.ts
+++ b/src/utils/getCustomConfiguration.ts
@@ -11,6 +11,7 @@ export type CustomConfig = {
   useMaintainers?: boolean;
   groupSourceComments?: boolean;
   output?: string;
+  customCommand?: string;
 };
 
 export const getCustomConfiguration = async (): Promise<CustomConfig | void> => {

--- a/src/utils/getGlobalOptions.ts
+++ b/src/utils/getGlobalOptions.ts
@@ -2,7 +2,7 @@ import { getCustomConfiguration } from './getCustomConfiguration';
 interface GlobalOptions {
   includes?: string[];
   output?: string;
-  customCommand?: string;
+  customRegenerationCommand?: string;
   groupSourceComments?: boolean;
 }
 export interface Command {

--- a/src/utils/getGlobalOptions.ts
+++ b/src/utils/getGlobalOptions.ts
@@ -2,7 +2,7 @@ import { getCustomConfiguration } from './getCustomConfiguration';
 interface GlobalOptions {
   includes?: string[];
   output?: string;
-
+  customCommand?: string;
   groupSourceComments?: boolean;
 }
 export interface Command {


### PR DESCRIPTION
Closes: https://github.com/gagoar/codeowners-generator/issues/173

Adds an option called `customRegenerationCommand` to specify a command to generate the codeowners file in the comment in the generated file.

For example: 

```
#################################### Generated content - do not edit! ####################################
# This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator)
# To re-generate, run \`npm run generate-codeowners\`. Don't worry, the content outside this block will be kept.
```
