### PR TITLE
ignoring package.json when is alongside a `CODEOWNERS` file

### DIFF
--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -1,0 +1,16 @@
+const ORIGINALS = {
+  log: global.console.log,
+  error: global.console.error,
+  info: global.console.info,
+  warn: global.console.warn,
+};
+
+type METHODS = 'log' | 'error' | 'info' | 'warn';
+export const mockConsole = (method: METHODS): jest.Mock => {
+  const handler = jest.fn();
+  global.console[method] = handler;
+  return handler;
+};
+export const unMockConsole = (method: METHODS): void => {
+  global.console[method] = ORIGINALS[method];
+};

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -45,11 +45,11 @@ export const generate: Generate = async ({ rootDir, includes, useMaintainers = f
       >;
 
       if (groups.json?.length) {
-        const dirNames = new Set(groups.txt?.map((path: string) => dirname(path)));
-        const filteredJSONs: string[] = groups.json.filter((file: string) => {
-          if (dirNames.has(dirname(file))) {
+        const codeownersDirNames = new Set(groups.txt?.map((path: string) => dirname(path)));
+        const filteredJSONs: string[] = groups.json.filter((packageJsonFile: string) => {
+          if (codeownersDirNames.has(dirname(packageJsonFile))) {
             console.warn(
-              `We will ignore the package.json ${file}, given that we have encountered a CODEOWNERS file at the same dir level`
+              `We will ignore the package.json ${packageJsonFile}, given that we have encountered a CODEOWNERS file at the same dir level`
             );
             return false;
           }


### PR DESCRIPTION
## Description

This PR fixes #193 

when having nested `CODEOWNERS` next to a package.json (in the same directory) we should avoid loading the `package.json` file to avoid duplicates. this is based on the assumption that `CODEOWNERS` are more granular than `pacakge.json` and it should be respected. 
