### PR TITLE
Create docsify site

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@
 
   <h3 align="center">codeowners-generator</h3>
   <p align="center">
-     <a href="https://github.com/gagoar/use-herald-action">
+     <a href="https://gagoar.github.io/codeowners-generator/">
         <img src="images/logo.png" alt="Logo" width="128" height="128">
     </a>
   </p>
   <p align="center">
     ✨ use codeowners anywhere in your monorepo 🛠️
     <br />
-    <a href="https://github.com/gagoar/codeowners-generator#table-of-contents"><strong>Explore the docs »</strong></a>
+    <a href="https://gagoar.github.io/codeowners-generator/"><strong>Explore the docs »</strong></a>
     <br />
     <a href="https://github.com/gagoar/codeowners-generator/issues">Report Bug</a>
     ·

--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Document</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+  <meta name="description" content="Description">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css">
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+    window.$docsify = {
+      name: '',
+      repo: ''
+    }
+  </script>
+  <!-- Docsify v4 -->
+  <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Document</title>
+  <title>Documentation | codeowners-generator</title>
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-  <meta name="description" content="Description">
+  <meta name="description" content="Documentation for codeowners-generator - use codeowners anywhere in your monorepo!">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
   <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css">
 </head>


### PR DESCRIPTION
## Description

This PR adds a [docsify](https://docsify.js.org/#/) index file so that `codeowners-generator` users have a nicer experience working through the documentation.

The toplevel README is the single source of truth for docsify, so a change to the README will cause the docsify site to automatically update.