### PR TITLE
Limit blank lines between original and generated

### DIFF
--- a/__tests__/generate.spec.ts
+++ b/__tests__/generate.spec.ts
@@ -75,7 +75,6 @@ describe('Generate', () => {
       # We might wanna keep an eye on something else, like yml files and workflows.
       .github/workflows/ @myOrg/infraTeam
 
-
       #################################### Generated content - do not edit! ####################################
       # This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator)
       # To re-generate, run \`yarn codeowners-generator generate\`. Don't worry, the content outside this block will be kept.

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -25,7 +25,8 @@ export const contentTemplate = (
   customRegenerationCommand?: string
 ): string => {
   return stripIndents`
-  ${originalContent && originalContent}
+  ${originalContent && originalContent.trimEnd()}
+
   ${CONTENT_MARK}
   ${getContentLegend(customRegenerationCommand)}\n
   ${generatedContent}\n


### PR DESCRIPTION
I've noticed that one new blank line is added between the original content and the generated content at every generation. This meant that the gap (number of blank lines) increased slow but steady.

My proposed solution in this PR is to trim the trailing blank lines from the original content but always add one blank line.