### PR TITLE
changing workflows to take node upgrades into account

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,19 @@
+name: lint
+
+on: [pull_request]
+
+jobs:
+  getNodeVersion:
+    uses: gagoar/github-app-installation-token/.github/workflows/node_version.yml@main
+
+  lint:
+    runs-on: ubuntu-latest
+    needs: getNodeVersion
+    steps:
+      - uses: actions/checkout@main
+      - name: Setting node version to ${{ needs.getNodeVersion.outputs.node_version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: '${{ needs.getNodeVersion.outputs.node_version }}'
+      - run: npm install
+      - run: npm run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: test
+
+on: [pull_request]
+
+jobs:
+  getNodeVersion:
+    uses: gagoar/github-app-installation-token/.github/workflows/node_version.yml@main
+
+  test:
+    runs-on: ubuntu-latest
+    needs: getNodeVersion
+    steps:
+      - uses: actions/checkout@main
+      - name: Setting node version to ${{ needs.getNodeVersion.outputs.node_version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: '${{ needs.getNodeVersion.outputs.node_version }}'
+      - run: npm install
+      - run: npm run test


### PR DESCRIPTION
In order to avoid issues with node, I've added a reusable workflow to take node version automagically. 

I've also divided up workflows just for visibility sake. 