### PR TITLE
Update renovate config to reduce noise

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,4 @@
 {
-  "extends": ["config:base"]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base", "schedule:monthly"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", "schedule:monthly"]
+  "extends": ["config:base", "schedule:monthly"],
+  "packageRules": [
+    {
+      "description": "Require dashboard approval for major updates",
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    }
+  ]
 }


### PR DESCRIPTION
Updates the Renovate config to create new PRs on a monthly basis and to require pre-approval of major updates (since they often require more planning than just merging).

This will help reduce noise and both can be overridden by ticking checkboxes in the [dependency dashboard issue](https://github.com/gagoar/codeowners-generator/issues/259) for a given dependency.