### PR TITLE
Remove unused dependency jest-mock-process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "eslint-config-prettier": "8.5.0",
         "husky": "8.0.1",
         "jest": "28.1.3",
-        "jest-mock-process": "1.5.1",
         "lint-staged": "13.0.3",
         "prettier": "2.7.1",
         "ts-jest": "28.0.6",
@@ -4977,15 +4976,6 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/jest-mock-process": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/jest-mock-process/-/jest-mock-process-1.5.1.tgz",
-      "integrity": "sha512-CPu46KyUiVSxE+LkqBuscqGmy1bvW2vJQuNstt83iLtFaFjgrgmp6LY04IKuOhhlGhcrdi86Gqq5/fTE2wG6lg==",
-      "dev": true,
-      "peerDependencies": {
-        "jest": ">=23.4 <29"
       }
     },
     "node_modules/jest-pnp-resolver": {
@@ -11419,13 +11409,6 @@
         "@jest/types": "^28.1.3",
         "@types/node": "*"
       }
-    },
-    "jest-mock-process": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/jest-mock-process/-/jest-mock-process-1.5.1.tgz",
-      "integrity": "sha512-CPu46KyUiVSxE+LkqBuscqGmy1bvW2vJQuNstt83iLtFaFjgrgmp6LY04IKuOhhlGhcrdi86Gqq5/fTE2wG6lg==",
-      "dev": true,
-      "requires": {}
     },
     "jest-pnp-resolver": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
     "eslint-config-prettier": "8.5.0",
     "husky": "8.0.1",
     "jest": "28.1.3",
-    "jest-mock-process": "1.5.1",
     "lint-staged": "13.0.3",
     "prettier": "2.7.1",
     "ts-jest": "28.0.6",


### PR DESCRIPTION
Another one. Removes `jest-mock-process` which seems to be unused.