### PR TITLE
Use renovate to update package reference in readme

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,21 @@
       "description": "Require dashboard approval for major updates",
       "matchUpdateTypes": ["major"],
       "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Update references to codeowners-generator in Markdown files weekly",
+      "matchPackageNames": ["codeowners-generator"],
+      "matchPaths": [".md"],
+      "commitMessageTopic": "Update references to {{{depName}}}",
+      "additionalBranchPrefix": "docs-"
+    }
+  ],
+  "regexManagers": [
+    {
+      "description": "Update codeowners-generator references in Markdown files",
+      "fileMatch": ["\\.md$"],
+      "matchStrings": ["\"(?<depName>codeowners-generator)\": \"(?<currentValue>.*?)\""],
+      "datasourceTemplate": "npm"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
       "dependencyDashboardApproval": true
     },
     {
-      "description": "Update references to codeowners-generator in Markdown files weekly",
+      "description": "Update codeowners-generator references in Markdown files",
       "matchPackageNames": ["codeowners-generator"],
       "matchPaths": [".md"],
       "commitMessageTopic": "Update references to {{{depName}}}",


### PR DESCRIPTION
I noticed there's an out of date reference to `codeowners-generator` in the readme. Instead of trying to keep it up to date manually, I'm thinking we can use Renovate to help us.

<img width="600" alt="Screenshot 2022-07-16 at 17 42 43" src="https://user-images.githubusercontent.com/644409/179361851-91d9a774-9bf9-4c29-bb55-420d29dade86.png">
