### PR TITLE
Remove duplicate Update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
       "description": "Update codeowners-generator references in Markdown files",
       "matchPackageNames": ["codeowners-generator"],
       "matchPaths": [".md"],
-      "commitMessageTopic": "Update references to {{{depName}}}",
+      "commitMessageTopic": "references to {{{depName}}}",
       "additionalBranchPrefix": "docs-"
     }
   ],


### PR DESCRIPTION
Turns out "Update" was added automatically by Renovate. Let's remove the duplicate

<img width="477" alt="Screenshot 2022-07-16 at 18 20 10" src="https://user-images.githubusercontent.com/644409/179363327-193888bd-0b94-4c0a-8a3a-4fff8f497f9f.png">
