### PR TITLE
Handle maintainers in root package.json files

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ You can configure `codeowners-generator` from several places:
 
 - **useMaintainers** (`--use-maintainers`): It will use `maintainers` field from package.json to generate codeowners, by default it will use `**/package.json`
 
+- **useRootMaintainers** (`--use-root-maintainers`): It will use `maintainers` field from the package.json in the root to generate default codeowners. Works only in conjunction with `useMaintainers`. `default: false`
+
 - **groupSourceComments** (`--group-source-comments`): Instead of generating one comment per rule, enabling this flag will group them, reducing comments to one per source file. Useful if your codeowners file gets too noisy.
 
 - **customRegenerationCommand** (`--custom-regeneration-command`): Specify a custom regeneration command to be printed in the generated CODEOWNERS file, it should be mapped to run codeowners-generator (e.g. "npm run codeowners").
@@ -139,6 +141,7 @@ You can also define custom configuration in your package:
     "includes": ["**/CODEOWNERS"],
     "output": ".github/CODEOWNERS",
     "useMaintainers": true,
+    "useRootMaintainers": true,
     "groupSourceComments": true,
     "customRegenerationCommand": "npm run codeowners"
   },

--- a/__tests__/generate.spec.ts
+++ b/__tests__/generate.spec.ts
@@ -532,7 +532,7 @@ describe('Generate', () => {
       callback(null, content);
     });
 
-    await generateCommand({ output: 'CODEOWNERS', useMaintainers: true }, { parent: {} });
+    await generateCommand({ output: 'CODEOWNERS', useMaintainers: true, useRootMaintainers: true }, { parent: {} });
     expect(writeFile.mock.calls[0][1]).toMatchInlineSnapshot(`
       "#################################### Generated content - do not edit! ####################################
       # This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator)

--- a/__tests__/generate.spec.ts
+++ b/__tests__/generate.spec.ts
@@ -515,6 +515,37 @@ describe('Generate', () => {
       #################################### Generated content - do not edit! ####################################"
     `);
   });
+  it('should generate a CODEOWNERS FILE with package.maintainers field for root package.json', async () => {
+    const packageFiles = {
+      'package.json': '../__mocks__/package1.json',
+      'dir2/package.json': '../__mocks__/package2.json',
+    };
+
+    sync.mockReturnValueOnce(['package.json', 'dir2/package.json']);
+
+    sync.mockReturnValueOnce(['.gitignore']);
+    const withAddedPackageFiles = { ...packageFiles, ...withGitIgnore };
+    readFile.mockImplementation((file, callback) => {
+      const content = readFileSync(
+        path.join(__dirname, withAddedPackageFiles[file as keyof typeof withAddedPackageFiles])
+      );
+      callback(null, content);
+    });
+
+    await generateCommand({ output: 'CODEOWNERS', useMaintainers: true }, { parent: {} });
+    expect(writeFile.mock.calls[0][1]).toMatchInlineSnapshot(`
+      "#################################### Generated content - do not edit! ####################################
+      # This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator)
+      # Don't worry, the content outside this block will be kept.
+
+      # Rule extracted from package.json
+      * friend@example.com other@example.com
+      # Rule extracted from dir2/package.json
+      /dir2/ friend@example.com other@example.com
+
+      #################################### Generated content - do not edit! ####################################"
+    `);
+  });
   it('should return rules', async () => {
     sync.mockReturnValueOnce(Object.keys(files));
     sync.mockReturnValueOnce(['.gitignore']);

--- a/src/utils/codeowners.ts
+++ b/src/utils/codeowners.ts
@@ -194,9 +194,16 @@ const getOwnersFromMaintainerField = (filePath: string, content: string): ownerR
         );
       }
 
+      let glob = join('/', dirname(filePath), '/');
+
+      if (glob === '/') {
+        // A slash ('/') for the root is not valid, using a glob-star is probably more reasonable.
+        glob = '*';
+      }
+
       return {
         filePath,
-        glob: join('/', dirname(filePath), '/'),
+        glob,
         owners,
       };
     } else {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -4,6 +4,7 @@ export const SHRUG_SYMBOL = '¯\\_(ツ)_/¯';
 export const OUTPUT = 'CODEOWNERS';
 export const INCLUDES = ['**/CODEOWNERS', '!CODEOWNERS', '!.github/CODEOWNERS', '!docs/CODEOWNERS', '!node_modules'];
 export const PACKAGE_JSON_PATTERN = ['**/package.json'];
+export const IGNORE_ROOT_PACKAGE_JSON_PATTERN = ['!package.json'];
 export const MAINTAINERS_EMAIL_PATTERN = /<(.+)>/;
 export const IGNORE_FILES_PATTERN = ['.gitignore'];
 export const CHARACTER_RANGE_PATTERN = /\[(?:.-.)+\]/;

--- a/src/utils/getCustomConfiguration.ts
+++ b/src/utils/getCustomConfiguration.ts
@@ -9,6 +9,7 @@ const debug = logger('customConfiguration');
 export type CustomConfig = {
   includes?: string[];
   useMaintainers?: boolean;
+  useRootMaintainers?: boolean;
   groupSourceComments?: boolean;
   output?: string;
   customRegenerationCommand?: string;


### PR DESCRIPTION
This PR makes sure package.json files in the root result in valid glob patterns. They will act like fallbacks. 

It adds an option (`useRootMaintainers`) to turn this on.

Closes: #329