### PR TITLE
adding Check functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ You can configure `codeowners-generator` from several places:
 
 - **customRegenerationCommand** (`--custom-regeneration-command`): Specify a custom regeneration command to be printed in the generated CODEOWNERS file, it should be mapped to run codeowners-generator (e.g. "npm run codeowners").
 
-- **check** (`--check`): It will fail if the CODEOWNERS generated doesn't match the current (or missing) CODEOWNERS . Useful for validating that the CODEOWNERS file is not out of date during CI.  
-  For more details you can invoke:
+- **check** (`--check`): It will fail if the CODEOWNERS generated doesn't match the current (or missing) CODEOWNERS . Useful for validating that the CODEOWNERS file is not out of date during CI.
+- For more details you can invoke:
 
 ```sh
   codeowners-generator --help

--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ You can configure `codeowners-generator` from several places:
 - **customRegenerationCommand** (`--custom-regeneration-command`): Specify a custom regeneration command to be printed in the generated CODEOWNERS file, it should be mapped to run codeowners-generator (e.g. "npm run codeowners").
 
 - **check** (`--check`): It will fail if the CODEOWNERS generated doesn't match the current (or missing) CODEOWNERS . Useful for validating that the CODEOWNERS file is not out of date during CI.
-- For more details you can invoke:
+
+For more details you can invoke:
 
 ```sh
   codeowners-generator --help

--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ You can configure `codeowners-generator` from several places:
 
 - **customRegenerationCommand** (`--custom-regeneration-command`): Specify a custom regeneration command to be printed in the generated CODEOWNERS file, it should be mapped to run codeowners-generator (e.g. "npm run codeowners").
 
-For more details you can invoke:
+- **check** (`--check`): It will fail if the CODEOWNERS generated doesn't match the current (or missing) CODEOWNERS . Useful for validating that the CODEOWNERS file is not out of date during CI.  
+  For more details you can invoke:
 
 ```sh
   codeowners-generator --help

--- a/__mocks__/CODEOWNERS_POPULATED_OUTPUT_2
+++ b/__mocks__/CODEOWNERS_POPULATED_OUTPUT_2
@@ -1,0 +1,29 @@
+# We are already using CODEOWNERS and we don't want to lose the content of this file.
+scripts/ @myOrg/infraTeam
+# We might wanna keep an eye on something else, like yml files and workflows.
+.github/workflows/ @myOrg/infraTeam
+
+#################################### Generated content - do not edit! ####################################
+# This block has been generated with codeowners-generator (for more information https://github.com/gagoar/codeowners-generator)
+# To re-generate, run `yarn codeowners-generator generate`. Don't worry, the content outside this block will be kept.
+
+# Rule extracted from dir1/CODEOWNERS
+/dir1/**/*.ts @eeny @meeny
+# Rule extracted from dir1/CODEOWNERS
+/dir1/*.ts @miny
+# Rule extracted from dir1/CODEOWNERS
+/dir1/**/README.md @miny
+# Rule extracted from dir1/CODEOWNERS
+/dir1/README.md @moe
+# Rule extracted from dir2/CODEOWNERS
+/dir2/**/*.ts @moe
+# Rule extracted from dir2/CODEOWNERS
+/dir2/dir3/*.ts @miny
+# Rule extracted from dir2/CODEOWNERS
+/dir2/**/*.md @meeny
+# Rule extracted from dir2/CODEOWNERS
+/dir2/**/dir4/ @eeny
+# Rule extracted from dir2/dir3/CODEOWNERS
+/dir2/dir3/**/*.ts @miny
+
+#################################### Generated content - do not edit! ####################################

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "eslint-config-prettier": "8.5.0",
         "husky": "8.0.1",
         "jest": "28.1.3",
+        "jest-mock-process": "^2.0.0",
         "lint-staged": "13.0.3",
         "prettier": "2.7.1",
         "ts-jest": "28.0.8",
@@ -1891,17 +1892,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ansi-colors": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/ansi-escapes": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
@@ -2312,9 +2302,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001336",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001336.tgz",
-      "integrity": "sha512-/YxSlBmL7iKXTbIJ48IQTnAOBk7XmWsxhBF1PZLOko5Dt9qc4Pl+84lfqG3Tc4EuavurRn1QLoVJGxY2iSycfw==",
+      "version": "1.0.30001462",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001462.tgz",
+      "integrity": "sha512-PDd20WuOBPiasZ7KbFnmQRyuLE7cFXW2PVd7dmALzbkUXEP46upAuCDm9eY9vho8fgNMGmbAX92QBZHzcnWIqw==",
       "dev": true,
       "funding": [
         {
@@ -2759,20 +2749,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
-    },
-    "node_modules/enquirer": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ansi-colors": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -4993,6 +4969,15 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/jest-mock-process": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jest-mock-process/-/jest-mock-process-2.0.0.tgz",
+      "integrity": "sha512-bybzszPfvrYhplymvUNFc130ryvjSCW1JSCrLA0LiV0Sv9TrI+cz90n3UYUPoT2nhNL6c6IV9LxUSFJF9L9tHQ==",
+      "dev": true,
+      "peerDependencies": {
+        "jest": ">=23.4"
       }
     },
     "node_modules/jest-pnp-resolver": {
@@ -9271,14 +9256,6 @@
         "uri-js": "^4.2.2"
       }
     },
-    "ansi-colors": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "ansi-escapes": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
@@ -9571,9 +9548,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001336",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001336.tgz",
-      "integrity": "sha512-/YxSlBmL7iKXTbIJ48IQTnAOBk7XmWsxhBF1PZLOko5Dt9qc4Pl+84lfqG3Tc4EuavurRn1QLoVJGxY2iSycfw==",
+      "version": "1.0.30001462",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001462.tgz",
+      "integrity": "sha512-PDd20WuOBPiasZ7KbFnmQRyuLE7cFXW2PVd7dmALzbkUXEP46upAuCDm9eY9vho8fgNMGmbAX92QBZHzcnWIqw==",
       "dev": true
     },
     "chalk": {
@@ -9907,17 +9884,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
-    },
-    "enquirer": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "ansi-colors": "^4.1.1"
-      }
     },
     "error-ex": {
       "version": "1.3.2",
@@ -11437,6 +11403,13 @@
         "@jest/types": "^28.1.3",
         "@types/node": "*"
       }
+    },
+    "jest-mock-process": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jest-mock-process/-/jest-mock-process-2.0.0.tgz",
+      "integrity": "sha512-bybzszPfvrYhplymvUNFc130ryvjSCW1JSCrLA0LiV0Sv9TrI+cz90n3UYUPoT2nhNL6c6IV9LxUSFJF9L9tHQ==",
+      "dev": true,
+      "requires": {}
     },
     "jest-pnp-resolver": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "eslint-config-prettier": "8.5.0",
     "husky": "8.0.1",
     "jest": "28.1.3",
+    "jest-mock-process": "^2.0.0",
     "lint-staged": "13.0.3",
     "prettier": "2.7.1",
     "ts-jest": "28.0.8",

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -31,7 +31,7 @@ program
   .option('--output [output file]', 'The output path and name of the file, (default: CODEOWNERS)')
   .option(
     '--check',
-    'If used it will exit with error if the top level CODEOWNERS file gets changed. Useful for CI validations'
+    'It will fail if the CODEOWNERS generated does not match the current (or missing) CODEOWNERS. Useful for validating that the CODEOWNERS file is up to date date during CI'
   )
   .action(generateCommand);
 

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -29,6 +29,10 @@ program
     'Specify a custom regeneration command to be printed in the generated CODEOWNERS file, it should be mapped to run codeowners-generator'
   )
   .option('--output [output file]', 'The output path and name of the file, (default: CODEOWNERS)')
+  .option(
+    '--check',
+    'If used it will exit with error if the top level CODEOWNERS file gets changed. Useful for CI validations'
+  )
   .action(generateCommand);
 
 program.parse(process.argv);

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -1,5 +1,6 @@
 import ora from 'ora';
 import { basename, dirname } from 'path';
+import fs from 'fs';
 import { sync } from 'fast-glob';
 import { Command, getGlobalOptions } from '../utils/getGlobalOptions';
 import {
@@ -10,7 +11,7 @@ import {
   PACKAGE_JSON_PATTERN,
   IGNORE_ROOT_PACKAGE_JSON_PATTERN,
 } from '../utils/constants';
-import { ownerRule, createOwnersFile, loadCodeOwnerFiles, loadOwnersFromPackage } from '../utils/codeowners';
+import { ownerRule, loadCodeOwnerFiles, loadOwnersFromPackage, generateOwnersFile } from '../utils/codeowners';
 import { logger } from '../utils/debug';
 import groupBy from 'lodash.groupby';
 import ignore from 'ignore';
@@ -137,17 +138,21 @@ export const command = async (options: Options, command: Command): Promise<void>
     });
 
     if (ownerRules.length) {
-      const [originalContent, newContent] = await createOwnersFile(
+      const [originalContent, newContent] = await generateOwnersFile(
         output,
         ownerRules,
         customRegenerationCommand,
         groupSourceComments
       );
 
-      if (originalContent.trimEnd() !== newContent && check) {
-        throw new Error(
-          'We found differences between the existing codeowners file and the generated. Remove --check option to avoid this error'
-        );
+      if (check) {
+        if (originalContent.trimEnd() !== newContent) {
+          throw new Error(
+            'We found differences between the existing codeowners file and the generated. Remove --check option to avoid this error'
+          );
+        }
+      } else {
+        fs.writeFileSync(output, newContent);
       }
       loader.stopAndPersist({ text: `CODEOWNERS file was created! location: ${output}`, symbol: SUCCESS_SYMBOL });
     } else {

--- a/src/utils/codeowners.ts
+++ b/src/utils/codeowners.ts
@@ -42,7 +42,7 @@ const filterGeneratedContent = (content: string) => {
     .join('\n');
 };
 type createOwnersFileResponse = [originalContent: string, newContent: string];
-export const createOwnersFile = async (
+export const generateOwnersFile = async (
   outputFile: string,
   ownerRules: ownerRule[],
   customRegenerationCommand?: string,
@@ -73,8 +73,6 @@ export const createOwnersFile = async (
     filterGeneratedContent(originalContent),
     customRegenerationCommand
   );
-
-  fs.writeFileSync(outputFile, normalizedContent);
 
   return [originalContent, normalizedContent];
 };


### PR DESCRIPTION
After a bit of discussion (mainly #335) we narrowed it down into a solution that will simplify the implementation of the action. 

The functionality `--check` does something very simple: It fails if the existing CODOWNERS file doesn't match the generated one. It will be useful to "lint" if the committed code is in fact matching what it should be. This functionality as said previously will simplify the action given that many developers seem to want just the check and not to generate the update within the workflow (Like I would have thought initially). 

I will provide documentation, but for now the code is complete and tested (unit test)