### PR TITLE
Fix it to work on Windows as well and add tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
     env:
-      DEBUG: '*'
+      DEBUG: 'codeowners-generator'
     steps:
       - uses: actions/checkout@v3
       - name: Setting node version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
+    env:
+      DEBUG: '*'
     steps:
       - uses: actions/checkout@v3
       - name: Setting node version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,13 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
     steps:
       - uses: actions/checkout@v3
       - name: Setting node version
@@ -18,11 +24,13 @@ jobs:
       - run: npm install
       - run: npm run test
       - name: Send coverage to codecov
+        if: matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests
       - name: Coveralls
+        if: matrix.os == 'ubuntu-latest'
         uses: coverallsapp/github-action@1.1.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,6 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
-    env:
-      DEBUG: 'codeowners-generator:*'
     steps:
       - uses: actions/checkout@v3
       - name: Setting node version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
     env:
-      DEBUG: 'codeowners-generator'
+      DEBUG: 'codeowners-generator:*'
     steps:
       - uses: actions/checkout@v3
       - name: Setting node version

--- a/__tests__/generate.spec.ts
+++ b/__tests__/generate.spec.ts
@@ -47,6 +47,7 @@ describe('Generate', () => {
   });
 
   it('should generate a CODEOWNERS file (re-using codeowners content) and not fail when using --check option', async () => {
+    mockProcessExit(false);
     sync.mockReturnValueOnce(Object.keys(files));
 
     sync.mockReturnValueOnce(['.gitignore']);
@@ -76,7 +77,7 @@ describe('Generate', () => {
     );
   });
   it('should generate a CODEOWNERS file (re-using codeowners content) and fail when using --check option', async () => {
-    const mockExit = mockProcessExit();
+    const mockExit = mockProcessExit(false);
 
     sync.mockReturnValueOnce(Object.keys(files));
 

--- a/__tests__/generate.spec.ts
+++ b/__tests__/generate.spec.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as fg from 'fast-glob';
 import { mockProcessExit } from 'jest-mock-process';
-import path from 'path';
+import path from 'path/posix';
 import { generateCommand } from '../';
 import { generate } from '../src/commands/generate';
 import { fail, stopAndPersist } from '../__mocks__/ora';

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -167,6 +167,7 @@ export const command = async (options: Options, command: Command): Promise<void>
     }
   } catch (e) {
     const error = e as Error;
+    debug(`We encountered an error: ${error.message}`);
     loader.fail(`We encountered an error: ${error.message}`);
     process.exit(1);
   }

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -1,5 +1,5 @@
 import ora from 'ora';
-import { basename, dirname } from 'path';
+import { basename, dirname } from 'path/posix';
 import fs from 'fs';
 import { sync } from 'fast-glob';
 import { Command, getGlobalOptions } from '../utils/getGlobalOptions';

--- a/src/utils/codeowners.ts
+++ b/src/utils/codeowners.ts
@@ -22,7 +22,7 @@ export type ownerRule = {
 };
 
 const filterGeneratedContent = (content: string): [withoutGeneratedCode: string[], blockPosition: number] => {
-  const lines = content.split('\n');
+  const lines = content.split(/\r?\n/);
 
   let skip = false;
   let generatedBlockPosition = -1;
@@ -94,7 +94,7 @@ export const generateOwnersFile = async (
 };
 
 const parseCodeOwner = (filePath: string, codeOwnerContent: string): ownerRule[] => {
-  const content = codeOwnerContent.split('\n');
+  const content = codeOwnerContent.split(/\r?\n/);
 
   // TODO: include comments optionally.
   const filteredRules = content.filter((line) => line && !line.startsWith('#'));

--- a/src/utils/codeowners.ts
+++ b/src/utils/codeowners.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import isGlob from 'is-glob';
-import { MAINTAINERS_EMAIL_PATTERN, CONTENT_MARK, CHARACTER_RANGE_PATTERN } from './constants';
+import { MAINTAINERS_EMAIL_PATTERN, CONTENT_MARK, CHARACTER_RANGE_PATTERN, LINE_ENDING_PATTERN } from './constants';
 import { dirname, join } from 'path/posix';
 import { readContent } from './readContent';
 import { logger } from '../utils/debug';
@@ -22,7 +22,7 @@ export type ownerRule = {
 };
 
 const filterGeneratedContent = (content: string): [withoutGeneratedCode: string[], blockPosition: number] => {
-  const lines = content.split(/\r?\n/);
+  const lines = content.split(LINE_ENDING_PATTERN);
 
   let skip = false;
   let generatedBlockPosition = -1;
@@ -94,7 +94,7 @@ export const generateOwnersFile = async (
 };
 
 const parseCodeOwner = (filePath: string, codeOwnerContent: string): ownerRule[] => {
-  const content = codeOwnerContent.split(/\r?\n/);
+  const content = codeOwnerContent.split(LINE_ENDING_PATTERN);
 
   // TODO: include comments optionally.
   const filteredRules = content.filter((line) => line && !line.startsWith('#'));

--- a/src/utils/codeowners.ts
+++ b/src/utils/codeowners.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import isGlob from 'is-glob';
 import { MAINTAINERS_EMAIL_PATTERN, CONTENT_MARK, CHARACTER_RANGE_PATTERN } from './constants';
-import { dirname, join } from 'path';
+import { dirname, join } from 'path/posix';
 import { readContent } from './readContent';
 import { logger } from '../utils/debug';
 import groupBy from 'lodash.groupby';

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -8,6 +8,8 @@ export const IGNORE_ROOT_PACKAGE_JSON_PATTERN = ['!package.json'];
 export const MAINTAINERS_EMAIL_PATTERN = /<(.+)>/;
 export const IGNORE_FILES_PATTERN = ['.gitignore'];
 export const CHARACTER_RANGE_PATTERN = /\[(?:.-.)+\]/;
+// A line ending can either be CRLF (\r\n) or LF (\n), common in Windows- and Unix-based systems respectively.
+export const LINE_ENDING_PATTERN = /\r?\n/;
 
 export const CONTENT_MARK = stripIndents`
 #################################### Generated content - do not edit! ####################################

--- a/src/utils/getPatternsFromIgnoreFiles.ts
+++ b/src/utils/getPatternsFromIgnoreFiles.ts
@@ -17,7 +17,7 @@ export const getPatternsFromIgnoreFiles = async (): Promise<string[]> => {
     matches.map(async (filePath) => {
       try {
         const content = await readContent(filePath);
-        const lines = content.split('\n').filter((line) => line && !line.startsWith('#'));
+        const lines = content.split(/\r?\n/).filter((line) => line && !line.startsWith('#'));
 
         return lines;
       } catch (e) {

--- a/src/utils/getPatternsFromIgnoreFiles.ts
+++ b/src/utils/getPatternsFromIgnoreFiles.ts
@@ -1,6 +1,6 @@
 import { logger } from './debug';
 import { sync } from 'fast-glob';
-import { IGNORE_FILES_PATTERN } from './constants';
+import { IGNORE_FILES_PATTERN, LINE_ENDING_PATTERN } from './constants';
 import { readContent } from './readContent';
 
 const debug = logger('parseIgnoreFiles');
@@ -17,7 +17,7 @@ export const getPatternsFromIgnoreFiles = async (): Promise<string[]> => {
     matches.map(async (filePath) => {
       try {
         const content = await readContent(filePath);
-        const lines = content.split(/\r?\n/).filter((line) => line && !line.startsWith('#'));
+        const lines = content.split(LINE_ENDING_PATTERN).filter((line) => line && !line.startsWith('#'));
 
         return lines;
       } catch (e) {


### PR DESCRIPTION
Fixes `codeowners-generator`, so it works on Windows as well. The PR also adds workflow tests for Windows and macOS, and a debugger comment if an error is thrown in `generate.ts`.

Fixes: https://github.com/gagoar/codeowners-generator/issues/371

The branch protection needs to be updated so the required check matches the new name `test (ubuntu-latest)`.

**Initial comment**

The first step here is just to try to run the test workflow on both Windows and macOS in addition to Ubuntu, to see if the issue in https://github.com/gagoar/codeowners-generator/issues/371 can be reproduced.

As expected the paths are incorrect on the try run on Windows:

```
       # Rule extracted from dir1/CODEOWNERS
    - /dir1/**/*.ts @eeny @meeny
    + \\dir1\\**\\*.ts @eeny @meeny
```