### PR TITLE
Fix path/posix usage not compatible with Node 12 and 14

### DIFF
--- a/__tests__/generate.spec.ts
+++ b/__tests__/generate.spec.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as fg from 'fast-glob';
 import { mockProcessExit } from 'jest-mock-process';
-import { posix as pathPosix } from 'path';
+import { posix as path } from 'path';
 import { generateCommand } from '../';
 import { generate } from '../src/commands/generate';
 import { fail, stopAndPersist } from '../__mocks__/ora';
@@ -58,7 +58,7 @@ describe('Generate', () => {
     };
     existsSync.mockReturnValue(true);
     readFile.mockImplementation((file, callback): void => {
-      const fullPath = pathPosix.join(
+      const fullPath = path.join(
         __dirname,
         withPopulatedCodeownersFile[file as keyof typeof withPopulatedCodeownersFile]
       );
@@ -89,7 +89,7 @@ describe('Generate', () => {
     };
     existsSync.mockReturnValue(true);
     readFile.mockImplementation((file, callback): void => {
-      const fullPath = pathPosix.join(
+      const fullPath = path.join(
         __dirname,
         withPopulatedCodeownersFile[file as keyof typeof withPopulatedCodeownersFile]
       );
@@ -116,7 +116,7 @@ describe('Generate', () => {
     };
     existsSync.mockReturnValue(true);
     readFile.mockImplementation((file, callback): void => {
-      const fullPath = pathPosix.join(
+      const fullPath = path.join(
         __dirname,
         withPopulatedCodeownersFile[file as keyof typeof withPopulatedCodeownersFile]
       );
@@ -181,7 +181,7 @@ describe('Generate', () => {
     };
     existsSync.mockReturnValue(true);
     readFile.mockImplementation((file, callback): void => {
-      const fullPath = pathPosix.join(
+      const fullPath = path.join(
         __dirname,
         withPopulatedCodeownersFile[file as keyof typeof withPopulatedCodeownersFile]
       );
@@ -243,7 +243,7 @@ describe('Generate', () => {
     sync.mockReturnValueOnce(['.gitignore']);
 
     readFile.mockImplementation((file, callback) => {
-      const content = readFileSync(pathPosix.join(__dirname, withGitIgnore[file as keyof typeof withGitIgnore]));
+      const content = readFileSync(path.join(__dirname, withGitIgnore[file as keyof typeof withGitIgnore]));
       callback(null, content);
     });
 
@@ -288,7 +288,7 @@ describe('Generate', () => {
     sync.mockReturnValueOnce(['.gitignore']);
 
     readFile.mockImplementation((file, callback) => {
-      const content = readFileSync(pathPosix.join(__dirname, withGitIgnore[file as keyof typeof withGitIgnore]));
+      const content = readFileSync(path.join(__dirname, withGitIgnore[file as keyof typeof withGitIgnore]));
       callback(null, content);
     });
 
@@ -355,7 +355,7 @@ describe('Generate', () => {
     const withAddedPackageFiles = { ...packageFiles, ...withGitIgnore };
     readFile.mockImplementation((file, callback) => {
       const content = readFileSync(
-        pathPosix.join(__dirname, withAddedPackageFiles[file as keyof typeof withAddedPackageFiles])
+        path.join(__dirname, withAddedPackageFiles[file as keyof typeof withAddedPackageFiles])
       );
       callback(null, content);
     });
@@ -431,7 +431,7 @@ describe('Generate', () => {
     const withAddedPackageFiles = { ...packageFiles, ...withGitIgnore };
     readFile.mockImplementation((file, callback) => {
       const content = readFileSync(
-        pathPosix.join(__dirname, withAddedPackageFiles[file as keyof typeof withAddedPackageFiles])
+        path.join(__dirname, withAddedPackageFiles[file as keyof typeof withAddedPackageFiles])
       );
       callback(null, content);
     });
@@ -501,7 +501,7 @@ describe('Generate', () => {
     const withAddedPackageFiles = { ...packageFiles, ...withGitIgnore };
     readFile.mockImplementation((file, callback) => {
       const content = readFileSync(
-        pathPosix.join(__dirname, withAddedPackageFiles[file as keyof typeof withAddedPackageFiles])
+        path.join(__dirname, withAddedPackageFiles[file as keyof typeof withAddedPackageFiles])
       );
       callback(null, content);
     });
@@ -562,7 +562,7 @@ describe('Generate', () => {
     const withAddedPackageFiles = { ...packageFiles, ...withGitIgnore };
     readFile.mockImplementation((file, callback) => {
       const content = readFileSync(
-        pathPosix.join(__dirname, withAddedPackageFiles[file as keyof typeof withAddedPackageFiles])
+        path.join(__dirname, withAddedPackageFiles[file as keyof typeof withAddedPackageFiles])
       );
       callback(null, content);
     });
@@ -616,7 +616,7 @@ describe('Generate', () => {
     const withAddedPackageFiles = { ...packageFiles, ...withGitIgnore };
     readFile.mockImplementation((file, callback) => {
       const content = readFileSync(
-        pathPosix.join(__dirname, withAddedPackageFiles[file as keyof typeof withAddedPackageFiles])
+        path.join(__dirname, withAddedPackageFiles[file as keyof typeof withAddedPackageFiles])
       );
       callback(null, content);
     });
@@ -671,7 +671,7 @@ describe('Generate', () => {
     const withAddedPackageFiles = { ...packageFiles, ...withGitIgnore };
     readFile.mockImplementation((file, callback) => {
       const content = readFileSync(
-        pathPosix.join(__dirname, withAddedPackageFiles[file as keyof typeof withAddedPackageFiles])
+        path.join(__dirname, withAddedPackageFiles[file as keyof typeof withAddedPackageFiles])
       );
       callback(null, content);
     });
@@ -699,7 +699,7 @@ describe('Generate', () => {
       ...withGitIgnore,
     };
     readFile.mockImplementation((file, callback) => {
-      const content = readFileSync(pathPosix.join(__dirname, filesWithIgnore[file as keyof typeof filesWithIgnore]));
+      const content = readFileSync(path.join(__dirname, filesWithIgnore[file as keyof typeof filesWithIgnore]));
       callback(null, content);
     });
 
@@ -817,7 +817,7 @@ describe('Generate', () => {
       ...withGitIgnore,
     };
     readFile.mockImplementation((file, callback) => {
-      const content = readFileSync(pathPosix.join(__dirname, filesWithIgnore[file as keyof typeof filesWithIgnore]));
+      const content = readFileSync(path.join(__dirname, filesWithIgnore[file as keyof typeof filesWithIgnore]));
       callback(null, content);
     });
     search.mockImplementationOnce(() => Promise.reject(new Error('some malformed configuration')));
@@ -837,7 +837,7 @@ describe('Generate', () => {
     sync.mockReturnValueOnce(['.gitignore']);
 
     readFile.mockImplementation((file, callback) => {
-      const content = readFileSync(pathPosix.join(__dirname, files[file as keyof typeof files]));
+      const content = readFileSync(path.join(__dirname, files[file as keyof typeof files]));
       callback(null, content);
     });
 

--- a/__tests__/generate.spec.ts
+++ b/__tests__/generate.spec.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as fg from 'fast-glob';
 import { mockProcessExit } from 'jest-mock-process';
-import path from 'path/posix';
+import { posix as pathPosix } from 'path';
 import { generateCommand } from '../';
 import { generate } from '../src/commands/generate';
 import { fail, stopAndPersist } from '../__mocks__/ora';
@@ -58,7 +58,7 @@ describe('Generate', () => {
     };
     existsSync.mockReturnValue(true);
     readFile.mockImplementation((file, callback): void => {
-      const fullPath = path.join(
+      const fullPath = pathPosix.join(
         __dirname,
         withPopulatedCodeownersFile[file as keyof typeof withPopulatedCodeownersFile]
       );
@@ -89,7 +89,7 @@ describe('Generate', () => {
     };
     existsSync.mockReturnValue(true);
     readFile.mockImplementation((file, callback): void => {
-      const fullPath = path.join(
+      const fullPath = pathPosix.join(
         __dirname,
         withPopulatedCodeownersFile[file as keyof typeof withPopulatedCodeownersFile]
       );
@@ -116,7 +116,7 @@ describe('Generate', () => {
     };
     existsSync.mockReturnValue(true);
     readFile.mockImplementation((file, callback): void => {
-      const fullPath = path.join(
+      const fullPath = pathPosix.join(
         __dirname,
         withPopulatedCodeownersFile[file as keyof typeof withPopulatedCodeownersFile]
       );
@@ -181,7 +181,7 @@ describe('Generate', () => {
     };
     existsSync.mockReturnValue(true);
     readFile.mockImplementation((file, callback): void => {
-      const fullPath = path.join(
+      const fullPath = pathPosix.join(
         __dirname,
         withPopulatedCodeownersFile[file as keyof typeof withPopulatedCodeownersFile]
       );
@@ -243,7 +243,7 @@ describe('Generate', () => {
     sync.mockReturnValueOnce(['.gitignore']);
 
     readFile.mockImplementation((file, callback) => {
-      const content = readFileSync(path.join(__dirname, withGitIgnore[file as keyof typeof withGitIgnore]));
+      const content = readFileSync(pathPosix.join(__dirname, withGitIgnore[file as keyof typeof withGitIgnore]));
       callback(null, content);
     });
 
@@ -288,7 +288,7 @@ describe('Generate', () => {
     sync.mockReturnValueOnce(['.gitignore']);
 
     readFile.mockImplementation((file, callback) => {
-      const content = readFileSync(path.join(__dirname, withGitIgnore[file as keyof typeof withGitIgnore]));
+      const content = readFileSync(pathPosix.join(__dirname, withGitIgnore[file as keyof typeof withGitIgnore]));
       callback(null, content);
     });
 
@@ -355,7 +355,7 @@ describe('Generate', () => {
     const withAddedPackageFiles = { ...packageFiles, ...withGitIgnore };
     readFile.mockImplementation((file, callback) => {
       const content = readFileSync(
-        path.join(__dirname, withAddedPackageFiles[file as keyof typeof withAddedPackageFiles])
+        pathPosix.join(__dirname, withAddedPackageFiles[file as keyof typeof withAddedPackageFiles])
       );
       callback(null, content);
     });
@@ -431,7 +431,7 @@ describe('Generate', () => {
     const withAddedPackageFiles = { ...packageFiles, ...withGitIgnore };
     readFile.mockImplementation((file, callback) => {
       const content = readFileSync(
-        path.join(__dirname, withAddedPackageFiles[file as keyof typeof withAddedPackageFiles])
+        pathPosix.join(__dirname, withAddedPackageFiles[file as keyof typeof withAddedPackageFiles])
       );
       callback(null, content);
     });
@@ -501,7 +501,7 @@ describe('Generate', () => {
     const withAddedPackageFiles = { ...packageFiles, ...withGitIgnore };
     readFile.mockImplementation((file, callback) => {
       const content = readFileSync(
-        path.join(__dirname, withAddedPackageFiles[file as keyof typeof withAddedPackageFiles])
+        pathPosix.join(__dirname, withAddedPackageFiles[file as keyof typeof withAddedPackageFiles])
       );
       callback(null, content);
     });
@@ -562,7 +562,7 @@ describe('Generate', () => {
     const withAddedPackageFiles = { ...packageFiles, ...withGitIgnore };
     readFile.mockImplementation((file, callback) => {
       const content = readFileSync(
-        path.join(__dirname, withAddedPackageFiles[file as keyof typeof withAddedPackageFiles])
+        pathPosix.join(__dirname, withAddedPackageFiles[file as keyof typeof withAddedPackageFiles])
       );
       callback(null, content);
     });
@@ -616,7 +616,7 @@ describe('Generate', () => {
     const withAddedPackageFiles = { ...packageFiles, ...withGitIgnore };
     readFile.mockImplementation((file, callback) => {
       const content = readFileSync(
-        path.join(__dirname, withAddedPackageFiles[file as keyof typeof withAddedPackageFiles])
+        pathPosix.join(__dirname, withAddedPackageFiles[file as keyof typeof withAddedPackageFiles])
       );
       callback(null, content);
     });
@@ -671,7 +671,7 @@ describe('Generate', () => {
     const withAddedPackageFiles = { ...packageFiles, ...withGitIgnore };
     readFile.mockImplementation((file, callback) => {
       const content = readFileSync(
-        path.join(__dirname, withAddedPackageFiles[file as keyof typeof withAddedPackageFiles])
+        pathPosix.join(__dirname, withAddedPackageFiles[file as keyof typeof withAddedPackageFiles])
       );
       callback(null, content);
     });
@@ -699,7 +699,7 @@ describe('Generate', () => {
       ...withGitIgnore,
     };
     readFile.mockImplementation((file, callback) => {
-      const content = readFileSync(path.join(__dirname, filesWithIgnore[file as keyof typeof filesWithIgnore]));
+      const content = readFileSync(pathPosix.join(__dirname, filesWithIgnore[file as keyof typeof filesWithIgnore]));
       callback(null, content);
     });
 
@@ -817,7 +817,7 @@ describe('Generate', () => {
       ...withGitIgnore,
     };
     readFile.mockImplementation((file, callback) => {
-      const content = readFileSync(path.join(__dirname, filesWithIgnore[file as keyof typeof filesWithIgnore]));
+      const content = readFileSync(pathPosix.join(__dirname, filesWithIgnore[file as keyof typeof filesWithIgnore]));
       callback(null, content);
     });
     search.mockImplementationOnce(() => Promise.reject(new Error('some malformed configuration')));
@@ -837,7 +837,7 @@ describe('Generate', () => {
     sync.mockReturnValueOnce(['.gitignore']);
 
     readFile.mockImplementation((file, callback) => {
-      const content = readFileSync(path.join(__dirname, files[file as keyof typeof files]));
+      const content = readFileSync(pathPosix.join(__dirname, files[file as keyof typeof files]));
       callback(null, content);
     });
 

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -1,5 +1,5 @@
 import ora from 'ora';
-import { posix as pathPosix } from 'path';
+import { posix as path } from 'path';
 import fs from 'fs';
 import { sync } from 'fast-glob';
 import { Command, getGlobalOptions } from '../utils/getGlobalOptions';
@@ -27,7 +27,7 @@ type GenerateInput = {
   includes?: string[];
 };
 
-const { basename, dirname } = pathPosix;
+const { basename, dirname } = path;
 
 export const generate: Generate = async ({ rootDir, includes, useMaintainers = false, useRootMaintainers = false }) => {
   debug('input:', rootDir, includes, useMaintainers, useRootMaintainers);

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -1,5 +1,5 @@
 import ora from 'ora';
-import { basename, dirname } from 'path/posix';
+import { posix as pathPosix } from 'path';
 import fs from 'fs';
 import { sync } from 'fast-glob';
 import { Command, getGlobalOptions } from '../utils/getGlobalOptions';
@@ -26,6 +26,8 @@ type GenerateInput = {
   useRootMaintainers?: boolean;
   includes?: string[];
 };
+
+const { basename, dirname } = pathPosix;
 
 export const generate: Generate = async ({ rootDir, includes, useMaintainers = false, useRootMaintainers = false }) => {
   debug('input:', rootDir, includes, useMaintainers, useRootMaintainers);

--- a/src/utils/codeowners.ts
+++ b/src/utils/codeowners.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import isGlob from 'is-glob';
 import { MAINTAINERS_EMAIL_PATTERN, CONTENT_MARK, CHARACTER_RANGE_PATTERN, LINE_ENDING_PATTERN } from './constants';
-import { posix as pathPosix } from 'path';
+import { posix as path } from 'path';
 import { readContent } from './readContent';
 import { logger } from '../utils/debug';
 import groupBy from 'lodash.groupby';
@@ -9,7 +9,7 @@ import { generatedContentTemplate, rulesBlockTemplate } from './templates';
 
 const debug = logger('utils/codeowners');
 
-const { dirname, join } = pathPosix;
+const { dirname, join } = path;
 
 const isString = (x: unknown): x is string => {
   return typeof x === 'string';

--- a/src/utils/codeowners.ts
+++ b/src/utils/codeowners.ts
@@ -1,13 +1,15 @@
 import fs from 'fs';
 import isGlob from 'is-glob';
 import { MAINTAINERS_EMAIL_PATTERN, CONTENT_MARK, CHARACTER_RANGE_PATTERN, LINE_ENDING_PATTERN } from './constants';
-import { dirname, join } from 'path/posix';
+import { posix as pathPosix } from 'path';
 import { readContent } from './readContent';
 import { logger } from '../utils/debug';
 import groupBy from 'lodash.groupby';
 import { generatedContentTemplate, rulesBlockTemplate } from './templates';
 
 const debug = logger('utils/codeowners');
+
+const { dirname, join } = pathPosix;
 
 const isString = (x: unknown): x is string => {
   return typeof x === 'string';


### PR DESCRIPTION
Found a bug for Node.js 12 and 14, which was introduced with the recent change in https://github.com/gagoar/codeowners-generator/pull/374

Found the bug while adding the CLI test: https://github.com/gagoar/codeowners-generator/pull/380