### PR TITLE
Run prettier in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,3 +17,4 @@ jobs:
           node-version-file: '.nvmrc'
       - run: npm install
       - run: npm run lint
+      - run: npm run prettier

--- a/package.json
+++ b/package.json
@@ -51,11 +51,6 @@
       "project": "./tsconfig.eslint.json"
     },
     "rules": {
-      "quotes": [
-        2,
-        "single",
-        "avoid-escape"
-      ],
       "no-debugger": "error",
       "no-process-env": "off",
       "import/prefer-default-export": "off",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "execute": "tsx src/bin/cli.ts",
     "version": "auto-changelog -p && git add CHANGELOG.md",
     "release": "npm run build && npm run build-cli && npm publish",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "prettier": "prettier --ignore-path .gitignore --check ."
   },
   "engines": {
     "node": ">10.0.0"


### PR DESCRIPTION
Run Prettier as part of the CI-pipeline.

Also, remove an ESLint rule which is already covered by Prettier (and otherwise turned off by `eslint-config-prettier`).