### PR TITLE
feat: Read rest of options from custom configuration file

### DIFF
--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -105,24 +105,26 @@ interface Options extends GlobalOptions {
 export const command = async (options: Options, command: Command): Promise<void> => {
   const globalOptions = await getGlobalOptions(command);
 
-  const { verifyPaths, useMaintainers, useRootMaintainers, check, preserveBlockPosition } = options;
+  const loader = ora(`generating codeowners...\n`).start();
 
-  const { output = globalOptions.output || OUTPUT } = options;
+  const { verifyPaths, check } = options;
 
-  const loader = ora('generating codeowners...').start();
+  const output = options.output || globalOptions.output || OUTPUT;
 
+  const useMaintainers = globalOptions.useMaintainers || options.useMaintainers;
+  const useRootMaintainers = globalOptions.useRootMaintainers || options.useRootMaintainers;
   const groupSourceComments = globalOptions.groupSourceComments || options.groupSourceComments;
-
+  const preserveBlockPosition = globalOptions.preserveBlockPosition || options.preserveBlockPosition;
   const customRegenerationCommand = globalOptions.customRegenerationCommand || options.customRegenerationCommand;
 
   debug('Options:', {
     ...globalOptions,
+    output,
     useMaintainers,
     useRootMaintainers,
     groupSourceComments,
     preserveBlockPosition,
     customRegenerationCommand,
-    output,
   });
 
   try {

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -21,7 +21,6 @@ const debug = logger('generate');
 type Generate = (options: GenerateInput) => Promise<ownerRule[]>;
 type GenerateInput = {
   rootDir: string;
-  verifyPaths?: boolean;
   useMaintainers?: boolean;
   useRootMaintainers?: boolean;
   includes?: string[];
@@ -98,14 +97,13 @@ export const generate: Generate = async ({ rootDir, includes, useMaintainers = f
 };
 
 interface Options extends GlobalOptions {
-  verifyPaths?: boolean;
   check?: boolean;
 }
 
 export const command = async (options: Options, command: Command): Promise<void> => {
   const globalOptions = await getGlobalOptions(command);
 
-  const { verifyPaths, check } = options;
+  const { check } = options;
 
   const output = options.output || globalOptions.output || OUTPUT;
 
@@ -130,7 +128,6 @@ export const command = async (options: Options, command: Command): Promise<void>
   try {
     const ownerRules = await generate({
       rootDir: __dirname,
-      verifyPaths,
       useMaintainers,
       useRootMaintainers,
       ...globalOptions,

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -105,11 +105,11 @@ interface Options extends GlobalOptions {
 export const command = async (options: Options, command: Command): Promise<void> => {
   const globalOptions = await getGlobalOptions(command);
 
-  const loader = ora(`generating codeowners...\n`).start();
-
   const { verifyPaths, check } = options;
 
   const output = options.output || globalOptions.output || OUTPUT;
+
+  const loader = ora('generating codeowners...').start();
 
   const useMaintainers = globalOptions.useMaintainers || options.useMaintainers;
   const useRootMaintainers = globalOptions.useRootMaintainers || options.useRootMaintainers;

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -2,7 +2,7 @@ import ora from 'ora';
 import { posix as path } from 'path';
 import fs from 'fs';
 import { sync } from 'fast-glob';
-import { Command, getGlobalOptions } from '../utils/getGlobalOptions';
+import { Command, GlobalOptions, getGlobalOptions } from '../utils/getGlobalOptions';
 import {
   OUTPUT,
   INCLUDES,
@@ -97,15 +97,8 @@ export const generate: Generate = async ({ rootDir, includes, useMaintainers = f
   }
 };
 
-interface Options {
-  output?: string;
+interface Options extends GlobalOptions {
   verifyPaths?: boolean;
-  useMaintainers?: boolean;
-  useRootMaintainers?: boolean;
-  groupSourceComments?: boolean;
-  preserveBlockPosition?: boolean;
-  includes?: string[];
-  customRegenerationCommand?: string;
   check?: boolean;
 }
 

--- a/src/utils/getCustomConfiguration.ts
+++ b/src/utils/getCustomConfiguration.ts
@@ -6,12 +6,14 @@ import packageJSON from '../../package.json';
 import { logger } from './debug';
 
 const debug = logger('customConfiguration');
+
 export type CustomConfig = {
   includes?: string[];
+  output?: string;
   useMaintainers?: boolean;
   useRootMaintainers?: boolean;
   groupSourceComments?: boolean;
-  output?: string;
+  preserveBlockPosition?: boolean;
   customRegenerationCommand?: string;
 };
 

--- a/src/utils/getGlobalOptions.ts
+++ b/src/utils/getGlobalOptions.ts
@@ -1,10 +1,6 @@
-import { getCustomConfiguration } from './getCustomConfiguration';
-interface GlobalOptions {
-  includes?: string[];
-  output?: string;
-  customRegenerationCommand?: string;
-  groupSourceComments?: boolean;
-}
+import { CustomConfig, getCustomConfiguration } from './getCustomConfiguration';
+
+export type GlobalOptions = CustomConfig;
 export interface Command {
   parent: Partial<GlobalOptions>;
 }


### PR DESCRIPTION
## Problem

Not all of the options that can be set through CLI flags are able to be read in from the custom config file. These being:
- `useMaintainers`
- `useRootMaintainers`
- `preserveBlockPosition`

It would improve dev experience to also set these in the custom config and have them be respected like the other options.

## Changes

- Update `generate` to read in the options mentioned above from custom config
- Connect the `CustomConfig`, `GlobalOptions` and `Options` types
- Small refactors