### PR TITLE
fix(action)!: Fix preserve-block-position default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,7 @@ runs:
           ARGS_INPUT+=("--check")
         fi
 
-        if [ ! -z "${{inputs.preserve-block-position}}" ]; then
+        if [ "${{inputs.preserve-block-position}}" = "true" ]; then
           ARGS_INPUT+=("--preserve-block-position")
         fi
 


### PR DESCRIPTION
Current logic adds `--preserve-block-position` to list of args if the length of the value provided to the `preserve-block-position` github actions variable is not zero. Since it defaults to the string `false`, this effectively defaults it to true. You can only disable it by setting it explicitly to an empty string. This PR corrects this logic by only enabling `preserve-block-position` if it's explicitly set to true.

BREAKING CHANGE: Effectively change default value for preserve-block-position in github actions