### PR TITLE
ci: use github app for release-please permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,14 +8,20 @@ on:
 jobs:
   release-please:
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
+      - name: Get token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
       - name: Release Please
         uses: google-github-actions/release-please-action@v3
         id: release
         with:
+          token: ${{ steps.app-token.outputs.token }}
           release-type: node
           package-name: codeowners-generator
       - name: Checkout repository


### PR DESCRIPTION
I noticed that we have an issue with [the release PR made by `release-please`](https://github.com/gagoar/codeowners-generator/pull/387). Since events triggered by the Github Actions bot won't trigger additional runs, the status checks aren't met as the workflows won't run.

One way to fix this is to set up a Github App user for `release-please` to use, that way it is a different user and as such the workflows will trigger.

If we choose this option, you need to create a Github App:

1. Go to [the app creation form](https://github.com/settings/apps/new) and give it a relevant name, e.g. `Codeowners-Generator Release Bot`.
2. Untick _Active_ under _Webhook_
3. Under _Repository permissions_ set `Contents: write` and `Pull-requests: write`, which are [the permissions that `release-please` needs](https://github.com/google-github-actions/release-please-action#workflow-permissions).
4. Make sure _Where can this GitHub App be installed?_ is set to _Only on this account_.
5. Click _Create Github App_
6. Generate a private key for the app.
7. Go to [the secrets settings for this repo](https://github.com/gagoar/codeowners-generator/settings/secrets/actions), create a secret named `RELEASE_PLEASE_PRIVATE_KEY` and set it to the content of the newly generated private key. Create another secret named `RELEASE_PLEASE_APP_ID` and set it to the App ID.
8. Last step is to install the app for the repo.