### PR TITLE
fix: only include relevant files in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "license": "MIT",
   "version": "2.4.0",
   "description": "CODEOWNERS generator for mono-repos",
+  "files": [
+    "build",
+    "dist"
+  ],
   "main": "build/index.js",
   "bin": {
     "codeowners-generator": "dist/cli.js"


### PR DESCRIPTION
I realized that all files are included in the published package, when only the the generated files in the `build` and `dist` directories are needed (apart from the `package.json` etc).

![Screenshot 2024-01-12 at 16 40 08](https://github.com/gagoar/codeowners-generator/assets/644409/829c01af-1c85-4164-9c6b-2179a2c2c5f0)

So with this change, only the needed files are included in the published package (the content after extracting the tarball generated by `npm pack`):

![Screenshot 2024-01-12 at 16 43 12](https://github.com/gagoar/codeowners-generator/assets/644409/8ebb9d35-d83d-4fed-b147-c4d2f26d58ff)
