### PR TITLE
docs: correct typos in package name config

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,11 +246,11 @@ When the command is invoked it will look for the `codeowners-generator` configur
 
 If you create any files matching the following patterns, `codeowners-generator` will pick them up:
 
-- a `codowners-generator` property in package.json
-- a `.codowners-generatorrc` file in JSON or YAML format
-- a `.codowners-generator.json`, `.codowners-generator.yaml`, `.codowners-generator.yml`, `.codowners-generator.js`, or `.codowners-generator.cjs` file
-- a `codowners-generatorrc`, `codowners-generator.json`, `codowners-generatorrc.yaml`, `codowners-generatorrc.yml`, `codowners-generator.js` or `codowners-generator.cjs` file inside a .config subdirectory
-- a `codowners-generator.config.js` or `codowners-generator.config.cjs` CommonJS module exporting an object
+- a `codeowners-generator` property in package.json
+- a `.codeowners-generatorrc` file in JSON or YAML format
+- a `.codeowners-generator.json`, `.codeowners-generator.yaml`, `.codeowners-generator.yml`, `.codeowners-generator.js`, or `.codeowners-generator.cjs` file
+- a `codeowners-generatorrc`, `codeowners-generator.json`, `codeowners-generatorrc.yaml`, `codeowners-generatorrc.yml`, `codeowners-generator.js` or `codeowners-generator.cjs` file inside a .config subdirectory
+- a `codeowners-generator.config.js` or `codeowners-generator.config.cjs` CommonJS module exporting an object
 
 For more insight into the custom configuration and where it can be defined check [cosmiconfig](https://github.com/davidtheclark/cosmiconfig)
 


### PR DESCRIPTION
Fixes small typos in the config filenames in the README