### PR TITLE
refactor: improve output messages

### DIFF
--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -145,13 +145,14 @@ export const command = async (options: Options, command: Command): Promise<void>
       if (check) {
         if (originalContent.trimEnd() !== newContent) {
           throw new Error(
-            'We found differences between the existing codeowners file and the generated. Remove --check option to avoid this error'
+            'We found differences between the existing codeowners file and the generated rules. Remove --check option to fix this.'
           );
         }
       } else {
         fs.writeFileSync(output, newContent);
       }
-      loader.stopAndPersist({ text: `CODEOWNERS file was created! location: ${output}`, symbol: SUCCESS_SYMBOL });
+      const message = check ? `up to date` : 'updated with the generated rules';
+      loader.stopAndPersist({ text: `CODEOWNERS file ${message}! location: ${output}`, symbol: SUCCESS_SYMBOL });
     } else {
       const includes = globalOptions.includes?.length ? globalOptions.includes : INCLUDES;
       loader.stopAndPersist({


### PR DESCRIPTION
`Remove --check option to avoid this error` is a little ambiguous (e.g., will it just suppress the error). Updated to let the user know what will happen if they remove it.

```sh
$ npx codeowners-generator generate --check
  
Custom configuration found in /Users/jared.mcateer/Projects/test/package.json
✖ We encountered an error: We found differences between the existing codeowners file and 
the generated rules. Remove --check option to fix this.
```

Added message for when `--check` is successful, rather than telling the user the file was created, which should not happen with that command. 

```sh
$ npx codeowners-generator generate --check
  
Custom configuration found in /Users/jared.mcateer/Projects/test/package.json
CODEOWNERS file up to date! location: .github/CODEOWNERS
```

Changed message for when new generated rules change the CO file, rather than saying a file was created, let them know the generated rules have changed. A CO file being created should be incredibly rare (i.e., maybe the first time this tool is run in a project). 

```sh
$ npx codeowners-generator generate

Custom configuration found in /Users/jared.mcateer/Projects/test/package.json
CODEOWNERS file updated with the generated rules! location: .github/CODEOWNERS
````