### PR TITLE
ci: Update test-cli.yml to remove outdated node versions

### DIFF
--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -42,8 +42,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         node-version:
-          - 12
-          - 14
           - 16
           - 18
           - 20


### PR DESCRIPTION
removing node `12` and `14` from the tests. Pretty deprecated already.